### PR TITLE
canOpenURL Background Thread & checkDYLD Case Insensitive compare

### DIFF
--- a/FrameworkClientApp/ViewController.swift
+++ b/FrameworkClientApp/ViewController.swift
@@ -12,7 +12,7 @@ import IOSSecuritySuite
 internal class ViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
-    
+
         let jailbreakStatus = IOSSecuritySuite.amIJailbrokenWithFailMessage()
         let title = jailbreakStatus.jailbroken ? "Jailbroken" : "Jailed"
         let message = """
@@ -23,7 +23,7 @@ internal class ViewController: UIViewController {
         """
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Dismiss", style: .default))
-        
+
         print("TEST: \(message)")
         present(alert, animated: false)
     }

--- a/IOSSecuritySuite.podspec
+++ b/IOSSecuritySuite.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "IOSSecuritySuite"
-  s.version      = "1.2"
+  s.version      = "1.3"
   s.summary      = "iOS platform security & anti-tampering Swift library"
   s.homepage     = "https://github.com/securing/IOSSecuritySuite"
   s.license      = "bsd-2-clause"
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.ios.frameworks = 'UIKit', 'Foundation'
   s.source       = { :git => "https://github.com/securing/IOSSecuritySuite.git", :tag => "#{s.version}" }
   s.source_files  = "IOSSecuritySuite/*.swift"
-  s.swift_version = '4.2'
+  s.swift_version = '5.0'
   s.requires_arc = true
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }
 end

--- a/IOSSecuritySuite.xcodeproj/project.pbxproj
+++ b/IOSSecuritySuite.xcodeproj/project.pbxproj
@@ -198,7 +198,7 @@
 					};
 					70B0BBBB226F3A4D000CFB39 = {
 						CreatedOnToolsVersion = 10.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1100;
 					};
 				};
 			};
@@ -489,7 +489,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -516,7 +516,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = biz.securing.IOSSecuritySuite;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/IOSSecuritySuite/DebuggerChecker.swift
+++ b/IOSSecuritySuite/DebuggerChecker.swift
@@ -12,7 +12,7 @@ internal class DebuggerChecker {
 
     // https://developer.apple.com/library/archive/qa/qa1361/_index.html
     static func amIDebugged() -> Bool {
-        
+
         var kinfo = kinfo_proc()
         var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
         var size = MemoryLayout<kinfo_proc>.stride
@@ -21,24 +21,24 @@ internal class DebuggerChecker {
         if sysctlRet != 0 {
             print("Error occured when calling sysctl(). The debugger check may be not reliable")
         }
-        
+
         return (kinfo.kp_proc.p_flag & P_TRACED) != 0
     }
-    
+
     static func denyDebugger() {
-        
+
         // bind ptrace()
         let pointerToPtrace = UnsafeMutableRawPointer(bitPattern: -2)
         let ptracePtr = dlsym(pointerToPtrace, "ptrace")
         typealias PtraceType = @convention(c) (CInt, pid_t, CInt, CInt) -> CInt
         let ptrace = unsafeBitCast(ptracePtr, to: PtraceType.self)
-        
+
         // PT_DENY_ATTACH == 31
         let ptraceRet = ptrace(31, 0, 0, 0)
-        
+
         if ptraceRet != 0 {
             print("Error occured when calling ptrace(). Denying debugger may not be reliable")
         }
     }
-    
+
 }

--- a/IOSSecuritySuite/EmulatorChecker.swift
+++ b/IOSSecuritySuite/EmulatorChecker.swift
@@ -9,24 +9,24 @@
 import Foundation
 
 internal class EmulatorChecker {
-    
+
     static func amIRunInEmulator() -> Bool {
-        
+
         return checkCompile() || checkRuntime()
     }
-    
+
     private static func checkRuntime() -> Bool {
-        
+
         return ProcessInfo().environment["SIMULATOR_DEVICE_NAME"] != nil
     }
-    
+
     private static func checkCompile() -> Bool {
-        
+
         #if targetEnvironment(simulator)
         return true
         #else
         return false
         #endif
     }
-    
+
 }

--- a/IOSSecuritySuite/IOSSecuritySuite.swift
+++ b/IOSSecuritySuite/IOSSecuritySuite.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public class IOSSecuritySuite {
-    
+
     /**
      This type method is used to determine the true/false jailbreak status
      
@@ -21,7 +21,7 @@ public class IOSSecuritySuite {
     public static func amIJailbroken() -> Bool {
         return JailbreakChecker.amIJailbroken()
     }
-    
+
     /**
      This type method is used to determine the jailbreak status with a message which jailbreak indicator was detected
      
@@ -42,7 +42,7 @@ public class IOSSecuritySuite {
     public static func amIJailbrokenWithFailMessage() -> (jailbroken: Bool, failMessage: String) {
         return JailbreakChecker.amIJailbrokenWithFailMessage()
     }
-    
+
     /**
      This type method is used to determine if application is run in emulator
      
@@ -54,7 +54,7 @@ public class IOSSecuritySuite {
     public static func amIRunInEmulator() -> Bool {
         return EmulatorChecker.amIRunInEmulator()
     }
-    
+
     /**
      This type method is used to determine if application is being debugged
      
@@ -66,7 +66,7 @@ public class IOSSecuritySuite {
     public static func amIDebugged() -> Bool {
         return DebuggerChecker.amIDebugged()
     }
-    
+
     /**
      This type method is used to deny debugger and improve the application resillency
      
@@ -78,7 +78,7 @@ public class IOSSecuritySuite {
     public static func denyDebugger() {
         return DebuggerChecker.denyDebugger()
     }
-    
+
     /**
      This type method is used to determine if there are any popular reverse engineering tools installed on the device
      
@@ -90,5 +90,5 @@ public class IOSSecuritySuite {
     public static func amIReverseEngineered() -> Bool {
         return ReverseEngineeringToolsChecker.amIReverseEngineered()
     }
-    
+
 }

--- a/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
+++ b/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
@@ -10,91 +10,91 @@ import Foundation
 import MachO // dyld
 
 internal class ReverseEngineeringToolsChecker {
-    
+
     static func amIReverseEngineered() -> Bool {
         return (checkDYLD() || checkExistenceOfSuspiciousFiles() || checkOpenedPorts())
     }
-    
+
     private static func checkDYLD() -> Bool {
-        
+
         let suspiciousLibraries = [
             "FridaGadget",
             "frida", // Needle injects frida-somerandom.dylib
             "cynject",
             "libcycript"
         ]
-        
+
         for libraryIndex in 0..<_dyld_image_count() {
-            
+
             // _dyld_get_image_name returns const char * that needs to be casted to Swift String
             guard let loadedLibrary = String(validatingUTF8: _dyld_get_image_name(libraryIndex)) else { continue }
-            
+
             for suspiciousLibrary in suspiciousLibraries {
-                if loadedLibrary.contains(suspiciousLibrary) {
+                if loadedLibrary.lowercased().contains(suspiciousLibrary.lowercased()) {
                     return true
                 }
             }
         }
-        
+
         return false
     }
-    
+
     private static func checkExistenceOfSuspiciousFiles() -> Bool {
-        
+
         let paths = [
             "/usr/sbin/frida-server"
         ]
-        
+
         for path in paths {
             if FileManager.default.fileExists(atPath: path) {
                 return true
             }
         }
-        
+
         return false
     }
-    
+
     private static func checkOpenedPorts() -> Bool {
-        
+
         let ports = [
             27042, // default Frida
             4444 // default Needle
         ]
-        
+
         for port in ports {
-            
+
             if canOpenLocalConnection(port: port) {
                 return true
             }
         }
-        
+
         return false
     }
-    
+
     private static func canOpenLocalConnection(port: Int) -> Bool {
-        
+
         func swapBytesIfNeeded(port: in_port_t) -> in_port_t {
             let littleEndian = Int(OSHostByteOrder()) == OSLittleEndian
             return littleEndian ? _OSSwapInt16(port) : port
         }
-        
+
         var serverAddress = sockaddr_in()
         serverAddress.sin_family = sa_family_t(AF_INET)
         serverAddress.sin_addr.s_addr = inet_addr("127.0.0.1")
         serverAddress.sin_port = swapBytesIfNeeded(port: in_port_t(port))
         let sock = socket(AF_INET, SOCK_STREAM, 0)
-        
+
         let result = withUnsafePointer(to: &serverAddress) {
             $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
                 connect(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.stride))
             }
         }
-        
+
         if result != -1 {
             return true // Port is opened
         }
-        
+
         return false
     }
-    
+
 }


### PR DESCRIPTION
Thanks for this great project.  This PR contains a few small tweaks for test cases I've found.

1) canOpenURL - Added condition that accounts for when the amIJailbroken is called in the background. Since UIApplication.shared.canOpenURL must always be collected on the main thread, have added logic that does a threading check and runs accordingly.

2) Case Insensitive checkDYLD - Made the _dyld_get_image_name comparison case insensitive to avoid skipping detections based on case.

3) SwiftInt update - have addressed the whitespace warnings

4) Upgrade to Swift 5.1