### PR TITLE
Expose a new public method to return a list of failed jailbreak checks

### DIFF
--- a/IOSSecuritySuite/IOSSecuritySuite.swift
+++ b/IOSSecuritySuite/IOSSecuritySuite.swift
@@ -44,15 +44,19 @@ public class IOSSecuritySuite {
     }
 
     /**
-        This type method is used to determine the jailbreak status with a list of failed checks
-    
-    - Returns: Tuple with with the jailbreak status *Bool* labeled *jailbroken* and *[FailedCheck]* labeled *failedChecks*
-     for the list of failed checks
+    This type method is used to determine the jailbreak status with a list of failed checks
 
      Usage example
      ```
-     //TODO: To be added
+     let jailbreakStatus = IOSSecuritySuite.amIJailbrokenWithFailedChecks()
+     if jailbreakStatus.jailbroken {
+     print("This device is jailbroken")
+     print("The following checks failed: \(jailbreakStatus.failedChecks)")
+     }
      ```
+
+     - Returns: Tuple with with the jailbreak status *Bool* labeled *jailbroken* and *[FailedCheck]* labeled *failedChecks*
+     for the list of failed checks
      */
     public static func amIJailbrokenWithFailedChecks() -> (jailbroken: Bool, failedChecks: [FailedCheck]) {
         return JailbreakChecker.amIJailbrokenWithFailedChecks()

--- a/IOSSecuritySuite/IOSSecuritySuite.swift
+++ b/IOSSecuritySuite/IOSSecuritySuite.swift
@@ -44,6 +44,21 @@ public class IOSSecuritySuite {
     }
 
     /**
+        This type method is used to determine the jailbreak status with a list of failed checks
+    
+    - Returns: Tuple with with the jailbreak status *Bool* labeled *jailbroken* and *[FailedCheck]* labeled *failedChecks*
+     for the list of failed checks
+
+     Usage example
+     ```
+     //TODO: To be added
+     ```
+     */
+    public static func amIJailbrokenWithFailedChecks() -> (jailbroken: Bool, failedChecks: [FailedCheck]) {
+        return JailbreakChecker.amIJailbrokenWithFailedChecks()
+    }
+
+    /**
      This type method is used to determine if application is run in emulator
      
      Usage example

--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -11,44 +11,78 @@ import UIKit
 import Darwin // fork
 import MachO // dyld
 
-internal class JailbreakChecker {
+public typealias CheckResult = (passed: Bool, failMessage: String)
+public typealias FailedCheck = (check: JailbreakCheck, failMessage: String)
 
+public struct JailbreakStatus {
+    let passed: Bool
+    let failMessage: String
+    let failedChecks: [FailedCheck]
+}
+
+public enum JailbreakCheck: CaseIterable {
+    case urlSchemes
+    case existenceOfSuspiciousFiles
+    case suspiciousFilesCanBeOpened
+    case restrictedDirectoriesWriteable
+    case fork
+    case symbolicLinks
+    case dyld
+}
+
+internal class JailbreakChecker {
     static func amIJailbroken() -> Bool {
         return !performChecks().passed
     }
 
     static func amIJailbrokenWithFailMessage() -> (jailbroken: Bool, failMessage: String) {
-        let performChecksReturn = performChecks()
-        return (!performChecksReturn.passed, performChecksReturn.failMessage)
+        let status = performChecks()
+        return (!status.passed, status.failMessage)
     }
 
-    private static func performChecks() -> (passed: Bool, failMessage: String) {
+    static func amIJailbrokenWithFailedChecks() -> (jailbroken: Bool, failedChecks: [FailedCheck]) {
+        let status = performChecks()
+        return (!status.passed, status.failedChecks)
+    }
 
-        let checklist = [
-            checkURLSchemes(),
-            checkExistenceOfSuspiciousFiles(),
-            checkSuspiciousFilesCanBeOpened(),
-            checkRestrictedDirectoriesWriteable(),
-            checkFork(),
-            checkSymbolicLinks(),
-            checkDYLD()
-        ]
-
+    private static func performChecks() -> JailbreakStatus {
         var passed = true
         var failMessage = ""
+        var result: CheckResult = (true, "")
+        var failedChecks: [FailedCheck] = []
 
-        for check in checklist {
-            passed = passed && check.passed
-            if !failMessage.isEmpty && !check.passed {
-                failMessage += ", "
+        for check in JailbreakCheck.allCases {
+            switch check {
+            case .urlSchemes:
+                result = checkURLSchemes()
+            case .existenceOfSuspiciousFiles:
+                result = checkExistenceOfSuspiciousFiles()
+            case .suspiciousFilesCanBeOpened:
+                result = checkSuspiciousFilesCanBeOpened()
+            case .restrictedDirectoriesWriteable:
+                result = checkRestrictedDirectoriesWriteable()
+            case .fork:
+                result = checkFork()
+            case .symbolicLinks:
+                result = checkSymbolicLinks()
+            case .dyld:
+                result = checkDYLD()
             }
-            failMessage += check.failMessage
+
+            passed = passed && result.passed
+
+            if !failMessage.isEmpty && !result.passed {
+                failMessage += ", "
+                failedChecks.append((check: check, failMessage: failMessage))
+            }
+
+            failMessage += result.failMessage
         }
 
-        return (passed, failMessage)
+        return JailbreakStatus(passed: passed, failMessage: failMessage, failedChecks: failedChecks)
     }
 
-    private static func canOpenUrlFromList(urlSchemes: [String]) -> (passed: Bool, failMessage: String) {
+    private static func canOpenUrlFromList(urlSchemes: [String]) -> CheckResult {
         for urlScheme in urlSchemes {
             if let url = URL(string: urlScheme) {
                 if UIApplication.shared.canOpenURL(url) {
@@ -59,7 +93,7 @@ internal class JailbreakChecker {
         return (true, "")
     }
 
-    private static func checkURLSchemes() -> (passed: Bool, failMessage: String) {
+    private static func checkURLSchemes() -> CheckResult {
         var flag: (passed: Bool, failMessage: String) = (true, "")
         let urlSchemes = [
             "undecimus://",
@@ -80,8 +114,7 @@ internal class JailbreakChecker {
         return flag
     }
 
-    private static func checkExistenceOfSuspiciousFiles() -> (passed: Bool, failMessage: String) {
-
+    private static func checkExistenceOfSuspiciousFiles() -> CheckResult {
         let paths = [
             "/usr/sbin/frida-server", // frida
             "/etc/apt/sources.list.d/electra.list", // electra
@@ -145,7 +178,7 @@ internal class JailbreakChecker {
         return (true, "")
     }
 
-    private static func checkSuspiciousFilesCanBeOpened() -> (passed: Bool, failMessage: String) {
+    private static func checkSuspiciousFilesCanBeOpened() -> CheckResult {
 
         let paths = [
             "/.installed_unc0ver",
@@ -169,7 +202,7 @@ internal class JailbreakChecker {
         return (true, "")
     }
 
-    private static func checkRestrictedDirectoriesWriteable() -> (passed: Bool, failMessage: String) {
+    private static func checkRestrictedDirectoriesWriteable() -> CheckResult {
 
         let paths = [
             "/",
@@ -192,7 +225,7 @@ internal class JailbreakChecker {
         return (true, "")
     }
 
-    private static func checkFork() -> (passed: Bool, failMessage: String) {
+    private static func checkFork() -> CheckResult {
 
         let pointerToFork = UnsafeMutableRawPointer(bitPattern: -2)
         let forkPtr = dlsym(pointerToFork, "fork")
@@ -210,7 +243,7 @@ internal class JailbreakChecker {
         return (true, "")
     }
 
-    private static func checkSymbolicLinks() -> (passed: Bool, failMessage: String) {
+    private static func checkSymbolicLinks() -> CheckResult {
 
         let paths = [
             "/var/lib/undecimus/apt", // unc0ver
@@ -235,7 +268,7 @@ internal class JailbreakChecker {
         return (true, "")
     }
 
-    private static func checkDYLD() -> (passed: Bool, failMessage: String) {
+    private static func checkDYLD() -> CheckResult {
 
         let suspiciousLibraries = [
             "SubstrateLoader.dylib",

--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -72,8 +72,11 @@ internal class JailbreakChecker {
             passed = passed && result.passed
 
             if !result.passed {
-                failMessage += ", "
-                failedChecks.append((check: check, failMessage: failMessage))
+                failedChecks.append((check: check, failMessage: result.failMessage))
+
+                if !failMessage.isEmpty {
+                    failMessage += ", "
+                }
             }
 
             failMessage += result.failMessage

--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -14,12 +14,6 @@ import MachO // dyld
 public typealias CheckResult = (passed: Bool, failMessage: String)
 public typealias FailedCheck = (check: JailbreakCheck, failMessage: String)
 
-public struct JailbreakStatus {
-    let passed: Bool
-    let failMessage: String
-    let failedChecks: [FailedCheck]
-}
-
 public enum JailbreakCheck: CaseIterable {
     case urlSchemes
     case existenceOfSuspiciousFiles
@@ -31,6 +25,12 @@ public enum JailbreakCheck: CaseIterable {
 }
 
 internal class JailbreakChecker {
+    struct JailbreakStatus {
+        let passed: Bool
+        let failMessage: String
+        let failedChecks: [FailedCheck]
+    }
+
     static func amIJailbroken() -> Bool {
         return !performChecks().passed
     }
@@ -71,7 +71,7 @@ internal class JailbreakChecker {
 
             passed = passed && result.passed
 
-            if !failMessage.isEmpty && !result.passed {
+            if !result.passed {
                 failMessage += ", "
                 failedChecks.append((check: check, failMessage: failMessage))
             }

--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -11,7 +11,6 @@ import UIKit
 import Darwin // fork
 import MachO // dyld
 
-public typealias CheckResult = (passed: Bool, failMessage: String)
 public typealias FailedCheck = (check: JailbreakCheck, failMessage: String)
 
 public enum JailbreakCheck: CaseIterable {
@@ -25,9 +24,11 @@ public enum JailbreakCheck: CaseIterable {
 }
 
 internal class JailbreakChecker {
+    typealias CheckResult = (passed: Bool, failMessage: String)
+
     struct JailbreakStatus {
         let passed: Bool
-        let failMessage: String
+        let failMessage: String // Added for backwards compatibility
         let failedChecks: [FailedCheck]
     }
 


### PR DESCRIPTION
##  What does this PR do?

This PR exposes a new public method to return a list of failed jailbreak checks.

It also includes a few minor changes / improvements in `JailbreakChecker`.

## Why do we need this?

In some cases jailbreaks might not properly clean up after themselves when you uninstall the jailbreak, leaving suspicious files behind. With these suspicious files being left behind `JailbreakChecker` will return a false positive even though the jailbreak was uninstalled.

To remedy this we need to return a list of all the failed checks in order to check and verify more conditions.

For example, we can now check the existence of suspicious files and also whether suspicious files can be opened:

```swift
let jailbreakStatus = IOSSecuritySuite.amIJailbrokenWithFailedChecks()

if jailbreakStatus.jailbroken {
   if (jailbreakStatus.failedChecks.contains { $0.check == .existenceOfSuspiciousFiles }) && (jailbreakStatus.failedChecks.contains { $0.check == .suspiciousFilesCanBeOpened }) {
         print("This is real jailbroken device")
   }
}
```

