### PR TITLE
Added notation to exclude app extensions

### DIFF
--- a/IOSSecuritySuite/IOSSecuritySuite.swift
+++ b/IOSSecuritySuite/IOSSecuritySuite.swift
@@ -10,6 +10,7 @@
 import Foundation
 import MachO
 
+@available(iOSApplicationExtension, unavailable)
 public class IOSSecuritySuite {
 
     /**
@@ -165,6 +166,7 @@ public class IOSSecuritySuite {
 }
 
 #if arch(arm64)
+@available(iOSApplicationExtension, unavailable)
 public extension IOSSecuritySuite {
     /**
     This type method is used to determine if `function_address` has been hooked by `MSHook`

--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -24,6 +24,7 @@ public enum JailbreakCheck: CaseIterable {
     case dyld
 }
 
+@available(iOSApplicationExtension, unavailable)
 internal class JailbreakChecker {
     typealias CheckResult = (passed: Bool, failMessage: String)
 

--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -24,7 +24,6 @@ public enum JailbreakCheck: CaseIterable {
     case dyld
 }
 
-@available(iOSApplicationExtension, unavailable)
 internal class JailbreakChecker {
     typealias CheckResult = (passed: Bool, failMessage: String)
 


### PR DESCRIPTION
Fix issue started on Xcode 13 beta 3

As this library is supposed to run only on iOS, so I guess it's safe to add the notation at the highest level.