### PR TITLE
Update JailbreakChecker.swift

### DIFF
--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -33,27 +33,27 @@ internal class JailbreakChecker {
         let failedChecks: [FailedCheck]
     }
 
-    static func amIJailbroken() -> Bool {
-        return !performChecks().passed
+    static func amIJailbroken(_ checks: [JailbreakCheck] = JailbreakCheck.allCases) -> Bool {
+        return !performChecks(checks).passed
     }
 
-    static func amIJailbrokenWithFailMessage() -> (jailbroken: Bool, failMessage: String) {
-        let status = performChecks()
+    static func amIJailbrokenWithFailMessage(_ checks: [JailbreakCheck] = JailbreakCheck.allCases) -> (jailbroken: Bool, failMessage: String) {
+        let status = performChecks(checks)
         return (!status.passed, status.failMessage)
     }
 
-    static func amIJailbrokenWithFailedChecks() -> (jailbroken: Bool, failedChecks: [FailedCheck]) {
-        let status = performChecks()
+    static func amIJailbrokenWithFailedChecks(_ checks: [JailbreakCheck] = JailbreakCheck.allCases) -> (jailbroken: Bool, failedChecks: [FailedCheck]) {
+        let status = performChecks(checks)
         return (!status.passed, status.failedChecks)
     }
 
-    private static func performChecks() -> JailbreakStatus {
+    private static func performChecks(_ checks: [JailbreakCheck]) -> JailbreakStatus {
         var passed = true
         var failMessage = ""
         var result: CheckResult = (true, "")
         var failedChecks: [FailedCheck] = []
 
-        for check in JailbreakCheck.allCases {
+        for check in checks {
             switch check {
             case .urlSchemes:
                 result = checkURLSchemes()


### PR DESCRIPTION
Hello,

Are you aware that some packages managers (eg: Sileo) have a demo version?
A demo IPA may be installed on a jailed device and thus lead to false positive, as Sileo demo app uses the same URL scheme.

I added an optional parameter to choose which checks to perform. I would also recommend you to add a few lines about this in your Read Me.

Best regards,