### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ After adding ISS to your project, you will also need to update your main Info.pl
 ```xml
 <key>LSApplicationQueriesSchemes</key>
 <array>
-    <string>cydia</string>
     <string>undecimus</string>
     <string>sileo</string>
     <string>zbra</string>
@@ -69,7 +68,7 @@ if jailbreakStatus.jailbroken {
 }
 ```
 The failMessage is a String containing comma-separated indicators as shown on the example below:
-`Cydia URL scheme detected, Suspicious file exists: /Library/MobileSubstrate/MobileSubstrate.dylib, Fork was able to create a new process`
+`sileo:// URL scheme detected, Suspicious file exists: /Library/MobileSubstrate/MobileSubstrate.dylib, Fork was able to create a new process`
 
 * **Verbose & filterable**, if you also want to for example identify devices that were jailbroken in the past, but now are jailed
 


### PR DESCRIPTION
`cydia://` url scheme is not used anymore, no need to add it to the `Info.plist`: 

See https://github.com/securing/IOSSecuritySuite/blob/4b23a52c4bb884a8cc8313dbc3d7ee4d91aaed0e/IOSSecuritySuite/JailbreakChecker.swift#L106