### PR TITLE
feat: check iOS app runs on macOS

### DIFF
--- a/IOSSecuritySuite.xcodeproj/project.pbxproj
+++ b/IOSSecuritySuite.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		259946DC29271F1700C7D46B /* MacChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259946DB29271F1700C7D46B /* MacChecker.swift */; };
 		703F74E222704E0F000635D8 /* ReverseEngineeringToolsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703F74E122704E0F000635D8 /* ReverseEngineeringToolsChecker.swift */; };
 		706B0E2A226F445D0059AEA9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706B0E29226F445D0059AEA9 /* AppDelegate.swift */; };
 		706B0E2C226F445D0059AEA9 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706B0E2B226F445D0059AEA9 /* ViewController.swift */; };
@@ -42,6 +43,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		259946DB29271F1700C7D46B /* MacChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacChecker.swift; sourceTree = "<group>"; };
 		703F74E122704E0F000635D8 /* ReverseEngineeringToolsChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReverseEngineeringToolsChecker.swift; sourceTree = "<group>"; };
 		706B0E27226F445D0059AEA9 /* FrameworkClientApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FrameworkClientApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		706B0E29226F445D0059AEA9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -134,6 +136,7 @@
 				A90FD5FF24528A94007212BF /* FishHookChecker.swift */,
 				A90FD60124528FD1007212BF /* RuntimeHookChecker.swift */,
 				70B8E16B257E528D00917097 /* ProxyChecker.swift */,
+				259946DB29271F1700C7D46B /* MacChecker.swift */,
 			);
 			path = IOSSecuritySuite;
 			sourceTree = "<group>";
@@ -300,6 +303,7 @@
 				70B0BBCD226F3A90000CFB39 /* EmulatorChecker.swift in Sources */,
 				70B8E16C257E528D00917097 /* ProxyChecker.swift in Sources */,
 				A90FD60224528FD1007212BF /* RuntimeHookChecker.swift in Sources */,
+				259946DC29271F1700C7D46B /* MacChecker.swift in Sources */,
 				A90FD5FE24528925007212BF /* MSHookFunctionChecker.swift in Sources */,
 				70B0BBCF226F3AB2000CFB39 /* IOSSecuritySuite.swift in Sources */,
 				703F74E222704E0F000635D8 /* ReverseEngineeringToolsChecker.swift in Sources */,

--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -191,8 +191,8 @@ internal class JailbreakChecker {
             "/Applications/Zebra.app" // Zebra
         ]
         
-        // These files can give false positive in the emulator
-        if !EmulatorChecker.amIRunInEmulator() {
+        // These files can give false positive in the emulator or mac
+        if !EmulatorChecker.amIRunInEmulator() && !MacChecker.amIRunInMac() {
             paths += [
             "/bin/bash",
             "/usr/sbin/sshd",
@@ -224,8 +224,8 @@ internal class JailbreakChecker {
             "/var/log/apt"
         ]
         
-        // These files can give false positive in the emulator
-        if !EmulatorChecker.amIRunInEmulator() {
+        // These files can give false positive in the emulator or mac
+        if !EmulatorChecker.amIRunInEmulator() && !MacChecker.amIRunInMac() {
             paths += [
             "/bin/bash",
             "/usr/sbin/sshd",

--- a/IOSSecuritySuite/MacChecker.swift
+++ b/IOSSecuritySuite/MacChecker.swift
@@ -1,0 +1,20 @@
+//
+//  MacChecker.swift
+//  IOSSecuritySuite
+//
+//  Created by bokuhe on 2022/11/18.
+//  Copyright © 2022 wregula. All rights reserved.
+//
+
+import Foundation
+
+internal class MacChecker {
+
+    static func amIRunInMac() -> Bool {
+        if #available(iOS 14.0, *) {
+            return ProcessInfo.processInfo.isiOSAppOnMac
+        } else {
+            return false
+        }
+    }
+}


### PR DESCRIPTION
Install and run the iOS app on the apple silicon mac 'amIJailbroken' fails due to some paths.

This commit allows some paths to be skipped when running on mac, same the emulator.

checkFork need not be skipped.