### PR TITLE
AntiMSHook - Cydia Substrate defense

### DIFF
--- a/IOSSecuritySuite/MSHookFunctionChecker.swift
+++ b/IOSSecuritySuite/MSHookFunctionChecker.swift
@@ -64,6 +64,7 @@ After MSHookFunction(mmap):
  |           br x16      (4 bytes for arm64)
  *------     address     (8 bytes for arm64)            address = original_function_address + 16
  
+ (For Cydia Substrate, the code block above doesn't guaranteed to be at the beginning of a region)
  */
 
 #if arch(arm64)
@@ -189,7 +190,9 @@ internal class MSHookFunctionChecker {
             return nil
         }
         // size of replaced instructions
-        guard let firstInstruction = MSHookInstruction.translateInstruction(at: functionAddr) else {
+        guard let firstInstruction = MSHookInstruction.translateInstruction(
+            at: functionAddr
+        ) else {
             assert(false, "amIMSHookFunction has judged")
             return nil
         }
@@ -204,7 +207,9 @@ internal class MSHookFunctionChecker {
             return nil
         }
         // look up vm_region
-        let vmRegionInfo = UnsafeMutablePointer<Int32>.allocate(capacity: MemoryLayout<vm_region_basic_info_64>.size/4)
+        let vmRegionInfo = UnsafeMutablePointer<Int32>.allocate(
+            capacity: MemoryLayout<vm_region_basic_info_64>.size/4
+        )
         defer {
             vmRegionInfo.deallocate()
         }


### PR DESCRIPTION
This PR is for #52 

Fixed MSHook deny function to properly deny MSHook with Cydia substrate.
**Currently MSHook with Cydia substrate is undeniable.**

Changes : 
 - MSHook with Cydia substrate does not guarantees to have branching address at the beginning of a vm region.
 - Thus, to get origin address of hooked target, we have to investigate whole vm region from top to bottom.
 - It might takes time in worst case : ```takes approx. 10.1380ms per symbol.```
 - For Substitute, nothing changed.

Tested : 

| Device | Arch. | OS | Time consumed (ms) |
| --- | --- | --- | --- |
| iPhoneSE 2 | arm64e | iOS 14.3 | 9.76 |
| iPhone 8 | arm64 | iOS 12.4 | 10.14 |
