### PR TITLE
Improve ReverseEngineeringToolsChecker as suggested in issue #79

### DIFF
--- a/IOSSecuritySuite.xcodeproj/project.pbxproj
+++ b/IOSSecuritySuite.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		70B0BBCF226F3AB2000CFB39 /* IOSSecuritySuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B0BBCE226F3AB2000CFB39 /* IOSSecuritySuite.swift */; };
 		70B8E16C257E528D00917097 /* ProxyChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B8E16B257E528D00917097 /* ProxyChecker.swift */; };
 		7A12583D24EFA8D40071460D /* IntegrityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A12583C24EFA8D40071460D /* IntegrityChecker.swift */; };
+		890685F829912FCF00EEC5A6 /* FailedChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 890685F729912FCF00EEC5A6 /* FailedChecks.swift */; };
 		A90FD5FE24528925007212BF /* MSHookFunctionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90FD5FD24528925007212BF /* MSHookFunctionChecker.swift */; };
 		A90FD60024528A94007212BF /* FishHookChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90FD5FF24528A94007212BF /* FishHookChecker.swift */; };
 		A90FD60224528FD1007212BF /* RuntimeHookChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90FD60124528FD1007212BF /* RuntimeHookChecker.swift */; };
@@ -60,6 +61,7 @@
 		70B8E16B257E528D00917097 /* ProxyChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyChecker.swift; sourceTree = "<group>"; };
 		70DDFD5A2284AA9600D95EE7 /* FrameworkClientApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FrameworkClientApp.entitlements; sourceTree = "<group>"; };
 		7A12583C24EFA8D40071460D /* IntegrityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrityChecker.swift; sourceTree = "<group>"; };
+		890685F729912FCF00EEC5A6 /* FailedChecks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailedChecks.swift; sourceTree = "<group>"; };
 		A90FD5FD24528925007212BF /* MSHookFunctionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSHookFunctionChecker.swift; sourceTree = "<group>"; };
 		A90FD5FF24528A94007212BF /* FishHookChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FishHookChecker.swift; sourceTree = "<group>"; };
 		A90FD60124528FD1007212BF /* RuntimeHookChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeHookChecker.swift; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 				70B0BBC0226F3A4D000CFB39 /* Info.plist */,
 				70B0BBC8226F3A74000CFB39 /* DebuggerChecker.swift */,
 				70B0BBCA226F3A86000CFB39 /* JailbreakChecker.swift */,
+				890685F729912FCF00EEC5A6 /* FailedChecks.swift */,
 				70B0BBCC226F3A90000CFB39 /* EmulatorChecker.swift */,
 				7A12583C24EFA8D40071460D /* IntegrityChecker.swift */,
 				70B0BBCE226F3AB2000CFB39 /* IOSSecuritySuite.swift */,
@@ -297,6 +300,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				70B0BBC9226F3A74000CFB39 /* DebuggerChecker.swift in Sources */,
+				890685F829912FCF00EEC5A6 /* FailedChecks.swift in Sources */,
 				70B0BBCD226F3A90000CFB39 /* EmulatorChecker.swift in Sources */,
 				70B8E16C257E528D00917097 /* ProxyChecker.swift in Sources */,
 				A90FD60224528FD1007212BF /* RuntimeHookChecker.swift in Sources */,

--- a/IOSSecuritySuite/FailedChecks.swift
+++ b/IOSSecuritySuite/FailedChecks.swift
@@ -1,0 +1,23 @@
+//
+//  FailedChecks.swift
+//  IOSSecuritySuite
+//
+//  Created by im on 06/02/23.
+//  Copyright © 2023 wregula. All rights reserved.
+//
+
+import Foundation
+
+public typealias FailedCheckType = (check: FailedCheck, failMessage: String)
+
+public enum FailedCheck: CaseIterable {
+    case urlSchemes
+    case existenceOfSuspiciousFiles
+    case suspiciousFilesCanBeOpened
+    case restrictedDirectoriesWriteable
+    case fork
+    case symbolicLinks
+    case dyld
+    case openedPorts
+    case pSelectFlag
+}

--- a/IOSSecuritySuite/IOSSecuritySuite.swift
+++ b/IOSSecuritySuite/IOSSecuritySuite.swift
@@ -61,7 +61,7 @@ public class IOSSecuritySuite {
      - Returns: Tuple with with the jailbreak status *Bool* labeled *jailbroken* and *[FailedCheck]* labeled *failedChecks*
      for the list of failed checks
      */
-    public static func amIJailbrokenWithFailedChecks() -> (jailbroken: Bool, failedChecks: [FailedCheck]) {
+    public static func amIJailbrokenWithFailedChecks() -> (jailbroken: Bool, failedChecks: [FailedCheckType]) {
         return JailbreakChecker.amIJailbrokenWithFailedChecks()
     }
 
@@ -132,7 +132,26 @@ public class IOSSecuritySuite {
     public static func amIReverseEngineered() -> Bool {
         return ReverseEngineeringToolsChecker.amIReverseEngineered()
     }
-    
+  
+    /**
+    This type method is used to determine the reverse engineered status with a list of failed checks
+
+     Usage example
+     ```
+     let reStatus = IOSSecuritySuite.amIReverseEngineeredWithFailedChecks()
+     if reStatus.reverseEngineered {
+        print("This device has evidence of reverse engineering")
+        print("The following checks failed: \(reStatus.failedChecks)")
+     }
+     ```
+
+     - Returns: Tuple with with the reverse engineered status *Bool* labeled *reverseEngineered* and *[FailedCheck]* labeled *failedChecks*
+     for the list of failed checks
+     */
+    public static func amIReverseEngineeredWithFailedChecks() -> (reverseEngineered: Bool, failedChecks: [FailedCheckType]) {
+        return ReverseEngineeringToolsChecker.amIReverseEngineeredWithFailedChecks()
+    }
+      
     /**
     This type method is used to determine if `objc call` has been RuntimeHooked by for example `Flex`
      

--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -12,25 +12,13 @@ import UIKit
 import Darwin // fork
 import MachO // dyld
 
-public typealias FailedCheck = (check: JailbreakCheck, failMessage: String)
-
-public enum JailbreakCheck: CaseIterable {
-    case urlSchemes
-    case existenceOfSuspiciousFiles
-    case suspiciousFilesCanBeOpened
-    case restrictedDirectoriesWriteable
-    case fork
-    case symbolicLinks
-    case dyld
-}
-
 internal class JailbreakChecker {
     typealias CheckResult = (passed: Bool, failMessage: String)
 
     struct JailbreakStatus {
         let passed: Bool
         let failMessage: String // Added for backwards compatibility
-        let failedChecks: [FailedCheck]
+        let failedChecks: [FailedCheckType]
     }
 
     static func amIJailbroken() -> Bool {
@@ -42,7 +30,7 @@ internal class JailbreakChecker {
         return (!status.passed, status.failMessage)
     }
 
-    static func amIJailbrokenWithFailedChecks() -> (jailbroken: Bool, failedChecks: [FailedCheck]) {
+    static func amIJailbrokenWithFailedChecks() -> (jailbroken: Bool, failedChecks: [FailedCheckType]) {
         let status = performChecks()
         return (!status.passed, status.failedChecks)
     }
@@ -51,9 +39,9 @@ internal class JailbreakChecker {
         var passed = true
         var failMessage = ""
         var result: CheckResult = (true, "")
-        var failedChecks: [FailedCheck] = []
-
-        for check in JailbreakCheck.allCases {
+        var failedChecks: [FailedCheckType] = []
+        
+        for check in FailedCheck.allCases {
             switch check {
             case .urlSchemes:
                 result = checkURLSchemes()
@@ -74,6 +62,8 @@ internal class JailbreakChecker {
                 result = checkSymbolicLinks()
             case .dyld:
                 result = checkDYLD()
+            default:
+                continue
             }
 
             passed = passed && result.passed
@@ -334,7 +324,7 @@ internal class JailbreakChecker {
 
             for suspiciousLibrary in suspiciousLibraries {
                 if loadedLibrary.lowercased().contains(suspiciousLibrary.lowercased()) {
-                    return(false, "Suspicious library loaded: \(loadedLibrary)")
+                    return (false, "Suspicious library loaded: \(loadedLibrary)")
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -102,6 +102,25 @@ let runInEmulator: Bool = IOSSecuritySuite.amIRunInEmulator()
 let amIReverseEngineered: Bool = IOSSecuritySuite.amIReverseEngineered()
 ```
 
+* **The simplest method** returns True/False if you just want to know if the device has evidence of reverse engineering
+
+```Swift
+if IOSSecuritySuite.amIReverseEngineered() {
+  print("This device has evidence of reverse engineering")
+} else {
+  print("This device hasn't evidence of reverse engineering")
+}
+```
+
+* **Verbose & filterable**, if you also want the list of checks done
+
+```Swift
+let reverseStatus = IOSSecuritySuite.amIReverseEngineeredWithFailedChecks()
+if reverseStatus.reverseEngineered {
+   // check for reverseStatus.failedChecks for more details
+}
+```
+
 ### System proxy detector module
 ```Swift
 let amIProxied: Bool = IOSSecuritySuite.amIProxied()

--- a/README.md
+++ b/README.md
@@ -98,9 +98,6 @@ let runInEmulator: Bool = IOSSecuritySuite.amIRunInEmulator()
 ```
 
 ### Reverse engineering tools detector module
-```Swift
-let amIReverseEngineered: Bool = IOSSecuritySuite.amIReverseEngineered()
-```
 
 * **The simplest method** returns True/False if you just want to know if the device has evidence of reverse engineering
 


### PR DESCRIPTION
Create `amIJailbrokenWithFailedChecks` that returns the reverseEngineered value and a list of checks done, as suggested in issue #79 