### PR TITLE
 Rename main class from `IOSSecuritySuite` to `SecuritySuiteiOS`

### DIFF
--- a/FrameworkClientApp/ViewController.swift
+++ b/FrameworkClientApp/ViewController.swift
@@ -20,7 +20,7 @@ class RuntimeClass {
 func testWatchpoint() -> Bool{
     var ptr = malloc(9)
     var count = 3
-    return IOSSecuritySuite.hasWatchpoint()
+    return SecuritySuiteiOS.hasWatchpoint()
 }
 
 internal class ViewController: UIViewController {
@@ -39,7 +39,7 @@ internal class ViewController: UIViewController {
         print("print hasn't been hooked")
         
         // antiHook
-        IOSSecuritySuite.denySymbolHook("$ss5print_9separator10terminatoryypd_S2StF")
+        SecuritySuiteiOS.denySymbolHook("$ss5print_9separator10terminatoryypd_S2StF")
         print("print has been antiHooked")
     }
 
@@ -50,10 +50,10 @@ internal class ViewController: UIViewController {
         let test = RuntimeClass.init()
         test.runtimeModifiedFunction()
         let dylds = ["UIKit"]
-        let amIRuntimeHooked = IOSSecuritySuite.amIRuntimeHooked(dyldWhiteList: dylds, detectionClass: RuntimeClass.self, selector: #selector(RuntimeClass.runtimeModifiedFunction), isClassMethod: false)
+        let amIRuntimeHooked = SecuritySuiteiOS.amIRuntimeHooked(dyldWhiteList: dylds, detectionClass: RuntimeClass.self, selector: #selector(RuntimeClass.runtimeModifiedFunction), isClassMethod: false)
         // MSHook Check
         func msHookReturnFalse(takes: Int) -> Bool {
-            /// add breakpoint at here to test `IOSSecuritySuite.hasBreakpointAt`
+            /// add breakpoint at here to test `SecuritySuiteiOS.hasBreakpointAt`
             return false
         }
         typealias FunctionType = @convention(thin) (Int) -> (Bool)
@@ -62,21 +62,21 @@ internal class ViewController: UIViewController {
         }
         let funcAddr = getSwiftFunctionAddr(msHookReturnFalse)
 
-        let jailbreakStatus = IOSSecuritySuite.amIJailbrokenWithFailMessage()
+        let jailbreakStatus = SecuritySuiteiOS.amIJailbrokenWithFailMessage()
         let title = jailbreakStatus.jailbroken ? "Jailbroken" : "Jailed"
         let message = """
         Jailbreak: \(jailbreakStatus.failMessage),
-        Run in emulator?: \(IOSSecuritySuite.amIRunInEmulator())
-        Debugged?: \(IOSSecuritySuite.amIDebugged())
-        HasBreakpoint?: \(IOSSecuritySuite.hasBreakpointAt(funcAddr, functionSize: nil))
+        Run in emulator?: \(SecuritySuiteiOS.amIRunInEmulator())
+        Debugged?: \(SecuritySuiteiOS.amIDebugged())
+        HasBreakpoint?: \(SecuritySuiteiOS.hasBreakpointAt(funcAddr, functionSize: nil))
         Has watchpoint: \(testWatchpoint())
-        Reversed?: \(IOSSecuritySuite.amIReverseEngineered())
-        Am I MSHooked: \(IOSSecuritySuite.amIMSHooked(funcAddr))
+        Reversed?: \(SecuritySuiteiOS.amIReverseEngineered())
+        Am I MSHooked: \(SecuritySuiteiOS.amIMSHooked(funcAddr))
         Am I runtime hooked: \(amIRuntimeHooked)
-        Am I tempered with: \(IOSSecuritySuite.amITampered([.bundleID("biz.securing.FrameworkClientApp")]).result)
-        Application executable file hash value: \(IOSSecuritySuite.getMachOFileHashValue() ?? "")
-        IOSSecuritySuite executable file hash value: \(IOSSecuritySuite.getMachOFileHashValue(.custom("IOSSecuritySuite")) ?? "")
-        Am I proxied: \(IOSSecuritySuite.amIProxied())
+        Am I tempered with: \(SecuritySuiteiOS.amITampered([.bundleID("biz.securing.FrameworkClientApp")]).result)
+        Application executable file hash value: \(SecuritySuiteiOS.getMachOFileHashValue() ?? "")
+        IOSSecuritySuite executable file hash value: \(SecuritySuiteiOS.getMachOFileHashValue(.custom("IOSSecuritySuite")) ?? "")
+        Am I proxied: \(SecuritySuiteiOS.amIProxied())
         """
         
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
@@ -85,11 +85,11 @@ internal class ViewController: UIViewController {
         print("FailMessage: \(message)")
         present(alert, animated: false)
 
-        let checks = IOSSecuritySuite.amIJailbrokenWithFailedChecks()
+        let checks = SecuritySuiteiOS.amIJailbrokenWithFailedChecks()
         print("The failed checks are: \(checks)")
         
 #if arch(arm64)
-        print("Loaded libs: \(IOSSecuritySuite.findLoadedDylibs() ?? [])")
+        print("Loaded libs: \(SecuritySuiteiOS.findLoadedDylibs() ?? [])")
 #endif
     }
 }

--- a/IOSSecuritySuite/SecuritySuiteiOS.swift
+++ b/IOSSecuritySuite/SecuritySuiteiOS.swift
@@ -1,5 +1,5 @@
 //
-//  IOSSecuritySuite.swift
+//  SecuritySuiteiOS.swift
 //  IOSSecuritySuite
 //
 //  Created by wregula on 23/04/2019.
@@ -11,14 +11,14 @@ import Foundation
 import MachO
 
 @available(iOSApplicationExtension, unavailable)
-public class IOSSecuritySuite {
+public class SecuritySuiteiOS {
 
     /**
      This type method is used to determine the true/false jailbreak status
      
      Usage example
      ```
-     let isDeviceJailbroken: Bool = IOSSecuritySuite.amIJailbroken()
+     let isDeviceJailbroken: Bool = SecuritySuiteiOS.amIJailbroken()
      ```
      */
     public static func amIJailbroken() -> Bool {
@@ -30,7 +30,7 @@ public class IOSSecuritySuite {
      
      Usage example
      ```
-     let jailbreakStatus = IOSSecuritySuite.amIJailbrokenWithFailMessage()
+     let jailbreakStatus = SecuritySuiteiOS.amIJailbrokenWithFailMessage()
      if jailbreakStatus.jailbroken {
      print("This device is jailbroken")
      print("Because: \(jailbreakStatus.failMessage)")
@@ -51,7 +51,7 @@ public class IOSSecuritySuite {
 
      Usage example
      ```
-     let jailbreakStatus = IOSSecuritySuite.amIJailbrokenWithFailedChecks()
+     let jailbreakStatus = SecuritySuiteiOS.amIJailbrokenWithFailedChecks()
      if jailbreakStatus.jailbroken {
      print("This device is jailbroken")
      print("The following checks failed: \(jailbreakStatus.failedChecks)")
@@ -70,7 +70,7 @@ public class IOSSecuritySuite {
      
      Usage example
      ```
-     let runInEmulator: Bool = IOSSecuritySuite.amIRunInEmulator()
+     let runInEmulator: Bool = SecuritySuiteiOS.amIRunInEmulator()
      ```
      */
     public static func amIRunInEmulator() -> Bool {
@@ -82,7 +82,7 @@ public class IOSSecuritySuite {
      
      Usage example
      ```
-     let amIDebugged: Bool = IOSSecuritySuite.amIDebugged()
+     let amIDebugged: Bool = SecuritySuiteiOS.amIDebugged()
      ```
      */
     public static func amIDebugged() -> Bool {
@@ -94,7 +94,7 @@ public class IOSSecuritySuite {
      
      Usage example
      ```
-     IOSSecuritySuite.denyDebugger()
+     SecuritySuiteiOS.denyDebugger()
      ```
      */
     public static func denyDebugger() {
@@ -106,7 +106,7 @@ public class IOSSecuritySuite {
     
     Usage example
     ```
-    if IOSSecuritySuite.amITampered([.bundleID("biz.securing.FrameworkClientApp"), .mobileProvision("your-mobile-provision-sha256-value")]).result {
+    if SecuritySuiteiOS.amITampered([.bundleID("biz.securing.FrameworkClientApp"), .mobileProvision("your-mobile-provision-sha256-value")]).result {
         print("I have been Tampered.")
     }
     else {
@@ -126,7 +126,7 @@ public class IOSSecuritySuite {
      
      Usage example
      ```
-     let amIReverseEngineered: Bool = IOSSecuritySuite.amIReverseEngineered()
+     let amIReverseEngineered: Bool = SecuritySuiteiOS.amIReverseEngineered()
      ```
      */
     public static func amIReverseEngineered() -> Bool {
@@ -138,7 +138,7 @@ public class IOSSecuritySuite {
 
      Usage example
      ```
-     let reStatus = IOSSecuritySuite.amIReverseEngineeredWithFailedChecks()
+     let reStatus = SecuritySuiteiOS.amIReverseEngineeredWithFailedChecks()
      if reStatus.reverseEngineered {
         print("This device has evidence of reverse engineering")
         print("The following checks failed: \(reStatus.failedChecks)")
@@ -176,7 +176,7 @@ public class IOSSecuritySuite {
      
     Usage example
     ```
-    let amIProxied: Bool = IOSSecuritySuite.amIProxied()
+    let amIProxied: Bool = SecuritySuiteiOS.amIProxied()
     ```
      */
     public static func amIProxied() -> Bool {
@@ -186,7 +186,7 @@ public class IOSSecuritySuite {
 
 #if arch(arm64)
 @available(iOSApplicationExtension, unavailable)
-public extension IOSSecuritySuite {
+public extension SecuritySuiteiOS {
     /**
     This type method is used to determine if `function_address` has been hooked by `MSHook`
     
@@ -276,7 +276,7 @@ public extension IOSSecuritySuite {
      Usage example
      ```
      // Manually verify SHA256 hash value of a loaded dylib
-     if let hashValue = IOSSecuritySuite.getMachOFileHashValue(.custom("IOSSecuritySuite")), hashValue == "6d8d460b9a4ee6c0f378e30f137cebaf2ce12bf31a2eef3729c36889158aa7fc" {
+     if let hashValue = SecuritySuiteiOS.getMachOFileHashValue(.custom("IOSSecuritySuite")), hashValue == "6d8d460b9a4ee6c0f378e30f137cebaf2ce12bf31a2eef3729c36889158aa7fc" {
          print("I have not been Tampered.")
      }
      else {
@@ -298,7 +298,7 @@ public extension IOSSecuritySuite {
      
      Usage example
      ```
-     if let loadedDylib = IOSSecuritySuite.findLoadedDylibs() {
+     if let loadedDylib = SecuritySuiteiOS.findLoadedDylibs() {
          print("Loaded dylibs: \(loadedDylib)")
      }
      ```
@@ -322,7 +322,7 @@ public extension IOSSecuritySuite {
     
     let func_denyDebugger: FunctionType = denyDebugger   // `: FunctionType` is a must
     let func_addr = unsafeBitCast(func_denyDebugger, to: UnsafeMutableRawPointer.self)
-    let hasBreakpoint: Bool = IOSSecuritySuite.hasBreakpointAt(func_addr, functionSize: nil)
+    let hasBreakpoint: Bool = SecuritySuiteiOS.hasBreakpointAt(func_addr, functionSize: nil)
     ```
     */
     static func hasBreakpointAt(_ functionAddr: UnsafeRawPointer, functionSize: vm_size_t?) -> Bool {

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ if IOSSecuritySuite.amIJailbroken() {
 * **Verbose**, if you also want to know what indicators were identified
 
 ```Swift
-let jailbreakStatus = IOSSecuritySuite.amIJailbrokenWithFailMessage()
+let jailbreakStatus = SecuritySuiteiOS.amIJailbrokenWithFailMessage()
 if jailbreakStatus.jailbroken {
 	print("This device is jailbroken")
 	print("Because: \(jailbreakStatus.failMessage)")
@@ -77,7 +77,7 @@ The failMessage is a String containing comma-separated indicators as shown on th
 * **Verbose & filterable**, if you also want to for example identify devices that were jailbroken in the past, but now are jailed
 
 ```Swift
-let jailbreakStatus = IOSSecuritySuite.amIJailbrokenWithFailedChecks()
+let jailbreakStatus = SecuritySuiteiOS.amIJailbrokenWithFailedChecks()
 if jailbreakStatus.jailbroken {
    if (jailbreakStatus.failedChecks.contains { $0.check == .existenceOfSuspiciousFiles }) && (jailbreakStatus.failedChecks.contains { $0.check == .suspiciousFilesCanBeOpened }) {
          print("This is real jailbroken device")
@@ -87,17 +87,17 @@ if jailbreakStatus.jailbroken {
 
 ### Debugger detector module
 ```Swift
-let amIDebugged: Bool = IOSSecuritySuite.amIDebugged()
+let amIDebugged: Bool = SecuritySuiteiOS.amIDebugged()
 ```
 
 ### Deny debugger at all
 ```Swift
-IOSSecuritySuite.denyDebugger()
+SecuritySuiteiOS.denyDebugger()
 ```
 
 ### Emulator detector module
 ```Swift
-let runInEmulator: Bool = IOSSecuritySuite.amIRunInEmulator()
+let runInEmulator: Bool = SecuritySuiteiOS.amIRunInEmulator()
 ```
 
 ### Reverse engineering tools detector module
@@ -105,7 +105,7 @@ let runInEmulator: Bool = IOSSecuritySuite.amIRunInEmulator()
 * **The simplest method** returns True/False if you just want to know if the device has evidence of reverse engineering
 
 ```Swift
-if IOSSecuritySuite.amIReverseEngineered() {
+if SecuritySuiteiOS.amIReverseEngineered() {
   print("This device has evidence of reverse engineering")
 } else {
   print("This device hasn't evidence of reverse engineering")
@@ -115,7 +115,7 @@ if IOSSecuritySuite.amIReverseEngineered() {
 * **Verbose & filterable**, if you also want the list of checks done
 
 ```Swift
-let reverseStatus = IOSSecuritySuite.amIReverseEngineeredWithFailedChecks()
+let reverseStatus = SecuritySuiteiOS.amIReverseEngineeredWithFailedChecks()
 if reverseStatus.reverseEngineered {
    // check for reverseStatus.failedChecks for more details
 }
@@ -123,7 +123,7 @@ if reverseStatus.reverseEngineered {
 
 ### System proxy detector module
 ```Swift
-let amIProxied: Bool = IOSSecuritySuite.amIProxied()
+let amIProxied: Bool = SecuritySuiteiOS.amIProxied()
 ```
 
 ## Experimental features
@@ -187,7 +187,7 @@ if let originalDenyDebugger = denyMSHook(funcAddr) {
 
 ```Swift
 // Determine if application has been tampered with 
-if IOSSecuritySuite.amITampered([.bundleID("biz.securing.FrameworkClientApp"),
+if SecuritySuiteiOS.amITampered([.bundleID("biz.securing.FrameworkClientApp"),
     .mobileProvision("2976c70b56e9ae1e2c8e8b231bf6b0cff12bbbd0a593f21846d9a004dd181be3"),
     .machO("IOSSecuritySuite", "6d8d460b9a4ee6c0f378e30f137cebaf2ce12bf31a2eef3729c36889158aa7fc")]).result {
     print("I have been Tampered.")
@@ -197,7 +197,7 @@ else {
 }
 
 // Manually verify SHA256 hash value of a loaded dylib
-if let hashValue = IOSSecuritySuite.getMachOFileHashValue(.custom("IOSSecuritySuite")), hashValue == "6d8d460b9a4ee6c0f378e30f137cebaf2ce12bf31a2eef3729c36889158aa7fc" {
+if let hashValue = SecuritySuiteiOS.getMachOFileHashValue(.custom("IOSSecuritySuite")), hashValue == "6d8d460b9a4ee6c0f378e30f137cebaf2ce12bf31a2eef3729c36889158aa7fc" {
     print("I have not been Tampered.")
 }
 else {
@@ -206,7 +206,7 @@ else {
  
 // Check SHA256 hash value of the main executable
 // Tip: Your application may retrieve this value from the server
-if let hashValue = IOSSecuritySuite.getMachOFileHashValue(.default), hashValue == "your-application-executable-hash-value" {
+if let hashValue = SecuritySuiteiOS.getMachOFileHashValue(.default), hashValue == "your-application-executable-hash-value" {
     print("I have not been Tampered.")
 }
 else {
@@ -224,7 +224,7 @@ func denyDebugger() {
 typealias FunctionType = @convention(thin) ()->()
 let func_denyDebugger: FunctionType = denyDebugger   // `: FunctionType` is a must
 let func_addr = unsafeBitCast(func_denyDebugger, to: UnsafeMutableRawPointer.self)
-let hasBreakpoint = IOSSecuritySuite.hasBreakpointAt(func_addr, functionSize: nil)
+let hasBreakpoint = SecuritySuiteiOS.hasBreakpointAt(func_addr, functionSize: nil)
 
 if hasBreakpoint {
     print("Breakpoint found in the specified function")
@@ -242,7 +242,7 @@ func testWatchpoint() -> Bool{
     var ptr = malloc(9)
     // lldb: watchpoint set variable count
     var count = 3
-    return IOSSecuritySuite.hasWatchpoint()
+    return SecuritySuiteiOS.hasWatchpoint()
 }
 ```
 


### PR DESCRIPTION
Fixes : #90 

Proposal, rename the `IOSSecuritySuite` to `SecuritySuiteiOS` to ensure that the library name doesn't clash with the Main class. 
This is an extreme approach, but has benefits
- Users of the library will only need to update the places where they're calling the library
- Decided to and the suffice `iOS` to indicate that this set of Security features are available for `iOS` 

So instead of 

```swift
if IOSSecuritySuite.amIJailbroken() {
	print("This device is jailbroken")
} else {
	print("This device is not jailbroken")
}
```
Becomes 

```swift
if SecuritySuiteiOS.amIJailbroken() {
	print("This device is jailbroken")
} else {
	print("This device is not jailbroken")
}
```

On the extreme end, this will be a breaking change, so it means this needs to be handled with extreme care. 