### PR TITLE
Some Improvements based on Jailbreak-detection-The-modern-way and Fixed a build error

### DIFF
--- a/FrameworkClientApp/ViewController.swift
+++ b/FrameworkClientApp/ViewController.swift
@@ -68,6 +68,7 @@ internal class ViewController: UIViewController {
         Jailbreak: \(jailbreakStatus.failMessage),
         Run in emulator?: \(IOSSecuritySuite.amIRunInEmulator())
         Debugged?: \(IOSSecuritySuite.amIDebugged())
+        Unexpected Launcher?: \(IOSSecuritySuite.isParentPidUnexpected())
         HasBreakpoint?: \(IOSSecuritySuite.hasBreakpointAt(funcAddr, functionSize: nil))
         Has watchpoint: \(testWatchpoint())
         Reversed?: \(IOSSecuritySuite.amIReverseEngineered())

--- a/FrameworkClientApp/ViewController.swift
+++ b/FrameworkClientApp/ViewController.swift
@@ -5,7 +5,7 @@
 //  Created by wregula on 23/04/2019.
 //  Copyright © 2019 wregula. All rights reserved.
 //
-//swiftlint:disable all
+// swiftlint:disable all
 
 import UIKit
 import IOSSecuritySuite
@@ -48,7 +48,7 @@ internal class ViewController: UIViewController {
         
         // Runtime Check
         let test = RuntimeClass.init()
-        test.runtimeModifiedFunction()
+        _ = test.runtimeModifiedFunction()
         let dylds = ["UIKit"]
         let amIRuntimeHooked = IOSSecuritySuite.amIRuntimeHooked(dyldWhiteList: dylds, detectionClass: RuntimeClass.self, selector: #selector(RuntimeClass.runtimeModifiedFunction), isClassMethod: false)
         // MSHook Check

--- a/IOSSecuritySuite.xcodeproj/project.pbxproj
+++ b/IOSSecuritySuite.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		A90FD5FE24528925007212BF /* MSHookFunctionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90FD5FD24528925007212BF /* MSHookFunctionChecker.swift */; };
 		A90FD60024528A94007212BF /* FishHookChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90FD5FF24528A94007212BF /* FishHookChecker.swift */; };
 		A90FD60224528FD1007212BF /* RuntimeHookChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90FD60124528FD1007212BF /* RuntimeHookChecker.swift */; };
+		E2814AD72A4E388100AC9E54 /* FileChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2814AD62A4E388100AC9E54 /* FileChecker.swift */; };
 		FF2FF25D2499F7590050D02F /* FishHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2FF25C2499F7590050D02F /* FishHook.swift */; };
 /* End PBXBuildFile section */
 
@@ -65,6 +66,7 @@
 		A90FD5FD24528925007212BF /* MSHookFunctionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSHookFunctionChecker.swift; sourceTree = "<group>"; };
 		A90FD5FF24528A94007212BF /* FishHookChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FishHookChecker.swift; sourceTree = "<group>"; };
 		A90FD60124528FD1007212BF /* RuntimeHookChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeHookChecker.swift; sourceTree = "<group>"; };
+		E2814AD62A4E388100AC9E54 /* FileChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileChecker.swift; sourceTree = "<group>"; };
 		FF2FF25C2499F7590050D02F /* FishHook.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FishHook.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -137,6 +139,7 @@
 				A90FD5FF24528A94007212BF /* FishHookChecker.swift */,
 				A90FD60124528FD1007212BF /* RuntimeHookChecker.swift */,
 				70B8E16B257E528D00917097 /* ProxyChecker.swift */,
+				E2814AD62A4E388100AC9E54 /* FileChecker.swift */,
 			);
 			path = IOSSecuritySuite;
 			sourceTree = "<group>";
@@ -301,6 +304,7 @@
 			files = (
 				70B0BBC9226F3A74000CFB39 /* DebuggerChecker.swift in Sources */,
 				890685F829912FCF00EEC5A6 /* FailedChecks.swift in Sources */,
+				E2814AD72A4E388100AC9E54 /* FileChecker.swift in Sources */,
 				70B0BBCD226F3A90000CFB39 /* EmulatorChecker.swift in Sources */,
 				70B8E16C257E528D00917097 /* ProxyChecker.swift in Sources */,
 				A90FD60224528FD1007212BF /* RuntimeHookChecker.swift in Sources */,

--- a/IOSSecuritySuite/DebuggerChecker.swift
+++ b/IOSSecuritySuite/DebuggerChecker.swift
@@ -104,5 +104,10 @@ internal class DebuggerChecker {
         return hasWatchpoint
     }
 #endif
-
+            
+    static func isParentPidUnexpected() -> Bool {
+        let parentPid: pid_t = getppid()
+        
+        return parentPid != 1 // LaunchD is pid 1
+    }
 }

--- a/IOSSecuritySuite/DebuggerChecker.swift
+++ b/IOSSecuritySuite/DebuggerChecker.swift
@@ -5,7 +5,7 @@
 //  Created by wregula on 23/04/2019.
 //  Copyright © 2019 wregula. All rights reserved.
 //
-//swiftlint:disable line_length
+// swiftlint:disable line_length trailing_whitespace
 
 import Foundation
 
@@ -86,16 +86,16 @@ internal class DebuggerChecker {
         var threadCount: mach_msg_type_number_t = 0
         var hasWatchpoint = false
         
-        if (task_threads(mach_task_self_, &threads, &threadCount) == KERN_SUCCESS) {
+        if task_threads(mach_task_self_, &threads, &threadCount) == KERN_SUCCESS {
             var threadStat = arm_debug_state64_t()
             let capacity = MemoryLayout<arm_debug_state64_t>.size / MemoryLayout<natural_t>.size
             let threadStatPointer = withUnsafeMutablePointer(to: &threadStat, { $0.withMemoryRebound(to: natural_t.self, capacity: capacity, { $0 }) })
             var count = mach_msg_type_number_t(MemoryLayout<arm_debug_state64_t>.size / MemoryLayout<UInt32>.size)
             
             for threadIndex in 0..<threadCount {
-                if (thread_get_state(threads![Int(threadIndex)], ARM_DEBUG_STATE64, threadStatPointer, &count) == KERN_SUCCESS) {
+                if thread_get_state(threads![Int(threadIndex)], ARM_DEBUG_STATE64, threadStatPointer, &count) == KERN_SUCCESS {
                     hasWatchpoint = threadStatPointer.withMemoryRebound(to: arm_debug_state64_t.self, capacity: 1, { $0 }).pointee.__wvr.0 != 0
-                    if (hasWatchpoint) { break }
+                    if hasWatchpoint { break }
                 }
             }
             vm_deallocate(mach_task_self_, UInt(bitPattern: threads), vm_size_t(threadCount * UInt32(MemoryLayout<thread_act_t>.size)))

--- a/IOSSecuritySuite/FailedChecks.swift
+++ b/IOSSecuritySuite/FailedChecks.swift
@@ -5,12 +5,33 @@
 //  Created by im on 06/02/23.
 //  Copyright © 2023 wregula. All rights reserved.
 //
+// swiftlint:disable trailing_whitespace
 
 import Foundation
 
 public typealias FailedCheckType = (check: FailedCheck, failMessage: String)
 
 public enum FailedCheck: CaseIterable {
+    
+    /**
+     Need to implement allCases to conform to CaseIterable when built by
+     Xcode 13.4.1, in order to be compatible with Xcode 14.x
+     */
+    public static var allCases: [FailedCheck] {
+        return [
+            .urlSchemes,
+            .existenceOfSuspiciousFiles,
+            .suspiciousFilesCanBeOpened,
+            .restrictedDirectoriesWriteable,
+            .fork,
+            .symbolicLinks,
+            .dyld,
+            .openedPorts,
+            .pSelectFlag,
+            .suspiciousObjCClasses
+        ]
+    }
+
     case urlSchemes
     case existenceOfSuspiciousFiles
     case suspiciousFilesCanBeOpened

--- a/IOSSecuritySuite/FailedChecks.swift
+++ b/IOSSecuritySuite/FailedChecks.swift
@@ -5,33 +5,12 @@
 //  Created by im on 06/02/23.
 //  Copyright © 2023 wregula. All rights reserved.
 //
-// swiftlint:disable trailing_whitespace
 
 import Foundation
 
 public typealias FailedCheckType = (check: FailedCheck, failMessage: String)
 
 public enum FailedCheck: CaseIterable {
-    
-    /**
-     Need to implement allCases to conform to CaseIterable when built by
-     Xcode 13.4.1, in order to be compatible with Xcode 14.x
-     */
-    public static var allCases: [FailedCheck] {
-        return [
-            .urlSchemes,
-            .existenceOfSuspiciousFiles,
-            .suspiciousFilesCanBeOpened,
-            .restrictedDirectoriesWriteable,
-            .fork,
-            .symbolicLinks,
-            .dyld,
-            .openedPorts,
-            .pSelectFlag,
-            .suspiciousObjCClasses
-        ]
-    }
-
     case urlSchemes
     case existenceOfSuspiciousFiles
     case suspiciousFilesCanBeOpened

--- a/IOSSecuritySuite/FileChecker.swift
+++ b/IOSSecuritySuite/FileChecker.swift
@@ -1,0 +1,237 @@
+//
+//  MountedVolumes.swift
+//  IOSSecuritySuite
+//
+//  Created by Mario Sepulveda on 6/29/23.
+//  Copyright © 2023 wregula. All rights reserved.
+//
+// swiftlint:disable trailing_whitespace
+
+import Foundation
+
+internal class FileChecker {
+    typealias CheckResult = (passed: Bool, failMessage: String)
+        
+    /**
+     Used to store some information provided by statfs()
+     */
+    struct MountedVolumeInfo {
+        let fileSystemName: String
+        let directoryName: String
+        let isRoot: Bool
+        let isReadOnly: Bool
+    }
+    
+    /**
+     Used to determine if a file access check should be in Write or Read-Only mode.
+     */
+    enum FileMode {
+        case readable
+        case writable
+    }
+    
+    /**
+     Given a path, this method provides information about the associated volume.
+     - Parameters:
+     - path: path is the pathname of any file within the mounted file system.
+     - Returns: Returns nil, if statfs() gives a non-zero result.
+     */
+    private static func getMountedVolumeInfoViaStatfs(path: String,
+                                                      encoding: String.Encoding = .utf8) -> MountedVolumeInfo? {
+        guard let path: [CChar] = path.cString(using: encoding) else {
+            assertionFailure("Failed to create a cString with path=\(path) encoding=\(encoding)")
+            return nil
+        }
+        
+        var statBuffer = statfs()
+        /**
+         Upon successful completion, the value 0 is returned; otherwise the
+         value -1 is returned and the global variable errno is set to indicate
+         the error.
+         */
+        let resultCode: Int32 = statfs(path, &statBuffer)
+        
+        if resultCode == 0 {
+            let mntFromName: String = withUnsafePointer(to: statBuffer.f_mntfromname) { ptr -> String in
+                return String(cString: UnsafeRawPointer(ptr).assumingMemoryBound(to: CChar.self))
+            }
+            let mntOnName: String = withUnsafePointer(to: statBuffer.f_mntonname) { ptr -> String in
+                return String(cString: UnsafeRawPointer(ptr).assumingMemoryBound(to: CChar.self))
+            }
+            
+            return MountedVolumeInfo(fileSystemName: mntFromName,
+                                     directoryName: mntOnName,
+                                     isRoot: (Int32(statBuffer.f_flags) & MNT_ROOTFS) != 0,
+                                     isReadOnly: (Int32(statBuffer.f_flags) & MNT_RDONLY) != 0)
+        } else {
+            return nil
+        }
+    }
+    
+    /**
+     This method provides information about all mounted volumes.
+     - Returns: Returns nil, if getfsstat() does not return any filesystem statistics.
+     */
+    private static func getMountedVolumesViaGetfsstat() -> [MountedVolumeInfo]? {
+        // If buf is NULL, getfsstat() returns just the number of mounted file systems.
+        let count: Int32 = getfsstat(nil, 0, MNT_NOWAIT)
+        
+        guard count >= 0 else {
+            assertionFailure("getfsstat() failed to return the number of mounted file systems.")
+            return nil
+        }
+        
+        var statBuffer: [statfs] = .init(repeating: .init(), count: Int(count))
+        let size: Int = MemoryLayout<statfs>.size * statBuffer.count
+        /**
+         Upon successful completion, the number of statfs structures is
+         returned. Otherwise, -1 is returned and the global variable errno is
+         set to indicate the error.
+         */
+        let resultCode: Int32 = getfsstat(&statBuffer, Int32(size), MNT_NOWAIT)
+        
+        if resultCode > -1 {
+            if count != resultCode {
+                assertionFailure("Unexpected a resultCode=\(resultCode), was expecting=\(count).")
+            }
+            
+            var result: [MountedVolumeInfo] = []
+            
+            for entry: statfs in statBuffer {
+                let mntFromName: String = withUnsafePointer(to: entry.f_mntfromname) { ptr -> String in
+                    return String(cString: UnsafeRawPointer(ptr).assumingMemoryBound(to: CChar.self))
+                }
+                let mntOnName: String = withUnsafePointer(to: entry.f_mntonname) { ptr -> String in
+                    return String(cString: UnsafeRawPointer(ptr).assumingMemoryBound(to: CChar.self))
+                }
+                
+                let info = MountedVolumeInfo(fileSystemName: mntFromName,
+                                             directoryName: mntOnName,
+                                             isRoot: (Int32(entry.f_flags) & MNT_ROOTFS) != 0,
+                                             isReadOnly: (Int32(entry.f_flags) & MNT_RDONLY) != 0)
+                result.append(info)
+            }
+            
+            if count != result.count {
+                assertionFailure("Unexpected filesystems count=\(result.count), was expecting=\(count).")
+            }
+            
+            return result
+        } else {
+            assertionFailure("getfsstat() failed. resultCode=\(resultCode), expected count=\(count) filesystems.")
+            return nil
+        }
+    }
+    
+    /**
+     Loops through the mounted volumes provided by Getfsstat() and searches for a match.
+     - Parameters:
+     - name: The filesystem name or mounted directory name to search for.
+     - Returns: Returns nil, if a matching mounted volume is not found.
+     */
+    private static func getMountedVolumesViaGetfsstat(withName name: String) -> MountedVolumeInfo? {
+        if let list = getMountedVolumesViaGetfsstat() {
+            if list.count == 0 {
+                assertionFailure("Expected to a non-empty list of mounted volumes.")
+            } else {
+                return list.first(where: { $0.directoryName == name || $0.fileSystemName == name })
+            }
+        } else {
+            assertionFailure("Expected a non-nil list of mounted volumes.")
+        }
+        return nil
+    }
+    
+    /**
+     Uses fopen() to check if an file exists and attempts to open it, in either Read-Only or Read-Write mode.
+     - Parameters:
+     - path: The file path to open.
+     - mode: Determines if the file will be opened in Writable or Read-Only mode.
+     - returns: Returns nil, if the file does not exist. Returns true if it can be opened with the given mode.
+     */
+    static func checkExistenceOfSuspiciousFilesViaFOpen(path: String,
+                                                        mode: FileMode) -> CheckResult? {
+        // the 'a' or 'w' modes, create the file if it does not exist.
+        let mode: String = FileMode.writable == mode ? "r+" : "r"
+        
+        if let filePointer: UnsafeMutablePointer<FILE> = fopen(path, mode) {
+            fclose(filePointer)
+            return (false, "Suspicious file exists: \(path)")
+        } else {
+            return nil
+        }
+    }
+    
+    /**
+     Uses stat() to check if a file exists.
+     - returns: Returns nil, if stat() returns a non-zero result code.
+     */
+    static func checkExistenceOfSuspiciousFilesViaStat(path: String) -> CheckResult? {
+        var statbuf: stat = stat()
+        let resultCode = stat((path as NSString).fileSystemRepresentation, &statbuf)
+        
+        if resultCode == 0 {
+            return (false, "Suspicious file exists: \(path)")
+        } else {
+            return nil
+        }
+    }
+    
+    /**
+     Uses access() to check whether the calling process can access the file path, in either Read-Only or Write mode.
+     - Parameters:
+     - path: The file path to open.
+     - mode: Determines if the file will be accessed in Write mode or Read-Only mode.
+     - returns: Returns nil, if access() returns a non-zero result code.
+     */
+    static func checkExistenceOfSuspiciousFilesViaAccess(path: String,
+                                                         mode: FileMode) -> CheckResult? {
+        let resultCode = access((path as NSString).fileSystemRepresentation, FileMode.writable == mode ? W_OK : R_OK)
+        
+        if resultCode == 0 {
+            return (false, "Suspicious file exists: \(path)")
+        } else {
+            return nil
+        }
+    }
+    
+    /**
+     Checks if statvfs() considers the given path to be Read-Only.
+     - Returns: Returns nil, if statvfs() gives a non-zero result.
+     */
+    static func checkRestrictedPathIsReadonlyViaStatvfs(path: String,
+                                                        encoding: String.Encoding = .utf8) -> Bool? {
+        guard let path: [CChar] = path.cString(using: encoding) else {
+            assertionFailure("Failed to create a cString with path=\(path) encoding=\(encoding)")
+            return nil
+        }
+        
+        var statBuffer = statvfs()
+        let resultCode: Int32 = statvfs(path, &statBuffer)
+        
+        if resultCode == 0 {
+            return Int32(statBuffer.f_flag) & ST_RDONLY != 0
+        } else {
+            return nil
+        }
+    }
+    
+    /**
+     Checks if statvs() considers the volume associated with given path to be Read-Only.
+     - Returns: Returns nil, if statfs() does not find the mounted volume.
+     */
+    static func checkRestrictedPathIsReadonlyViaStatfs(path: String,
+                                                       encoding: String.Encoding = .utf8) -> Bool? {
+        return getMountedVolumeInfoViaStatfs(path: path, encoding: encoding)?.isReadOnly
+    }
+    
+    /**
+     Checks if Getfsstat() considers the volume to be Read-Only.
+     - Parameters:
+     - name: The filesystem name or mounted directory name to search for.
+     - Returns: Returns nil, if a matching mounted volume is not found.
+     */
+    static func checkRestrictedPathIsReadonlyViaGetfsstat(name: String) -> Bool? {
+        return self.getMountedVolumesViaGetfsstat(withName: name)?.isReadOnly
+    }
+}

--- a/IOSSecuritySuite/FishHookChecker.swift
+++ b/IOSSecuritySuite/FishHookChecker.swift
@@ -5,7 +5,7 @@
 //  Created by jintao on 2020/4/24.
 //  Copyright © 2020 wregula. All rights reserved.
 //  https://github.com/TannerJin/anti-fishhook
-// swiftlint:disable trailing_whitespace control_statement line_length cyclomatic_complexity type_body_length function_body_length
+// swiftlint:disable trailing_whitespace control_statement line_length cyclomatic_complexity type_body_length function_body_length file_length
 import Foundation
 import MachO
 

--- a/IOSSecuritySuite/IOSSecuritySuite.swift
+++ b/IOSSecuritySuite/IOSSecuritySuite.swift
@@ -5,7 +5,7 @@
 //  Created by wregula on 23/04/2019.
 //  Copyright © 2019 wregula. All rights reserved.
 //
-//swiftlint:disable line_length
+// swiftlint:disable line_length trailing_whitespace
 
 import Foundation
 import MachO
@@ -99,6 +99,19 @@ public class IOSSecuritySuite {
      */
     public static func denyDebugger() {
         return DebuggerChecker.denyDebugger()
+    }
+    
+    /**
+     This method is used to determine if application was launched by something
+     other than LaunchD (i.e. the app was launched by a debugger)
+     
+     Usage example
+     ```
+     let isNotLaunchD: Bool = IOSSecuritySuite.isParentPidUnexpected()
+     ```
+     */
+    public static func isParentPidUnexpected() -> Bool {
+        return DebuggerChecker.isParentPidUnexpected()
     }
     
     /**

--- a/IOSSecuritySuite/IntegrityChecker.swift
+++ b/IOSSecuritySuite/IntegrityChecker.swift
@@ -5,7 +5,7 @@
 //  Created by NikoXu on 2020/8/21.
 //  Copyright © 2020 wregula. All rights reserved.
 //
-// swiftlint:disable line_length large_tuple force_cast
+// swiftlint:disable line_length large_tuple force_cast trailing_whitespace
 
 import Foundation
 import MachO

--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -335,7 +335,10 @@ internal class JailbreakChecker {
             "Cephei",
             "Electra",
             "AppSyncUnified-FrontBoard.dylib",
-            "Shadow"
+            "Shadow",
+            "FridaGadget",
+            "frida",
+            "libcycript"
         ]
         
         for libraryIndex in 0..<_dyld_image_count() {

--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -5,7 +5,7 @@
 //  Created by wregula on 23/04/2019.
 //  Copyright © 2019 wregula. All rights reserved.
 //
-//swiftlint:disable cyclomatic_complexity function_body_length type_body_length
+// swiftlint:disable cyclomatic_complexity function_body_length type_body_length trailing_whitespace file_length
 
 import Foundation
 import UIKit

--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -376,9 +376,9 @@ internal class JailbreakChecker {
     
     private static func checkSuspiciousObjCClasses() -> CheckResult {
         
-        if let ShadowRulesetClass = objc_getClass("ShadowRuleset") as? NSObject.Type {
+        if let shadowRulesetClass = objc_getClass("ShadowRuleset") as? NSObject.Type {
             let selector = Selector(("isURLSchemeRestricted:"))
-            if class_getInstanceMethod(ShadowRulesetClass, selector) != nil {
+            if class_getInstanceMethod(shadowRulesetClass, selector) != nil {
                 return (false, "Shadow anti-anti-jailbreak detector detected :-)")
             }
         }

--- a/IOSSecuritySuite/MSHookFunctionChecker.swift
+++ b/IOSSecuritySuite/MSHookFunctionChecker.swift
@@ -220,11 +220,11 @@ internal class MSHookFunctionChecker {
         
         while true {
             if vmRegionAddress == 0 {
-                //False address
+                // False address
                 return nil
             }
             
-            //Get VM region of designated address
+            // Get VM region of designated address
             if vm_region_64(
                 mach_task_self_,
                 &vmRegionAddress,
@@ -234,7 +234,7 @@ internal class MSHookFunctionChecker {
                 &vmRegionInfoCount,
                 &objectName
             ) != KERN_SUCCESS {
-                //End of vm_regions or something wrong
+                // End of vm_regions or something wrong
                 return nil
             }
             
@@ -244,7 +244,7 @@ internal class MSHookFunctionChecker {
             
             // vm region of code
             if regionInfo.pointee.protection != (VM_PROT_READ|VM_PROT_EXECUTE) {
-                //Memory protection level of executable region is always READ + EXECUTE
+                // Memory protection level of executable region is always READ + EXECUTE
                 vmRegionAddress += vmRegionSize
                 continue
             }
@@ -252,16 +252,16 @@ internal class MSHookFunctionChecker {
             // ldr (Mobile Substrate)
             if case .ldr_x16 = firstInstruction {
                 
-                //Current vm region instruction address
+                // Current vm region instruction address
                 var vmRegionProcedureAddr = vmRegionAddress
-                //Current vm region instruction address
+                // Current vm region instruction address
                 var vmRegionInstAddr = vmRegionAddress
-                //Last address of current vm region
+                // Last address of current vm region
                 let vmRegionEndAddress = vmRegionAddress + vmRegionSize
                 
-                //Unlike substitute, When using substrate, branching address may resides anywhere in vm region.
-                //So every region must be investigated to check whether it contains original function address.
-                while (vmRegionEndAddress >= vmRegionInstAddr) {
+                // Unlike substitute, When using substrate, branching address may resides anywhere in vm region.
+                // So every region must be investigated to check whether it contains original function address.
+                while vmRegionEndAddress >= vmRegionInstAddr {
                     vmRegionInstAddr += 4
                     guard let instructionAddr = UnsafeMutablePointer<UnsafeMutableRawPointer>(
                         bitPattern: Int(vmRegionInstAddr)

--- a/IOSSecuritySuite/ProxyChecker.swift
+++ b/IOSSecuritySuite/ProxyChecker.swift
@@ -5,6 +5,7 @@
 //  Created by Wojciech Reguła on 07/12/2020.
 //  Copyright © 2020 wregula. All rights reserved.
 //
+// swiftlint:disable trailing_whitespace
 
 import Foundation
 

--- a/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
+++ b/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
@@ -5,6 +5,7 @@
 //  Created by wregula on 24/04/2019.
 //  Copyright © 2019 wregula. All rights reserved.
 //
+// swiftlint:disable trailing_whitespace
 
 import Foundation
 import MachO // dyld

--- a/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
+++ b/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
@@ -99,7 +99,9 @@ internal class ReverseEngineeringToolsChecker {
 
         let ports = [
             27042, // default Frida
-            4444 // default Needle
+            4444, // default Needle
+            22, // OpenSSH
+            44 // checkra1n
         ]
 
         for port in ports {

--- a/IOSSecuritySuite/RuntimeHookChecker.swift
+++ b/IOSSecuritySuite/RuntimeHookChecker.swift
@@ -5,7 +5,7 @@
 //  Created by jintao on 2020/4/24.
 //  Copyright © 2020 wregula. All rights reserved.
 //
-//swiftlint:disable line_length
+// swiftlint:disable line_length
 
 import Foundation
 import MachO


### PR DESCRIPTION
Some Improvements based on https://github.com/vadim-a-yegorov/Jailbreak-detection-The-modern-way

- Adds support for checking the Parent process id.
- Add checking for known OpenSSH and checkra1n open ports.
- Add additional checking for libraries names:
-- FridaGadget
-- frida
-- libcycript
- Add check for existence of Suspicious Files with:
-- stat()
-- fopen()
-- access
- Add check for non read-only "/" path with:
--  statvfs()
-- statfs()
-- getfsstat()
- Resolve build error due SwiftLint rule **identifier_name** rule 
- Resolve various swiftlint warnings