### PR TITLE
Improve performance of `checkDYLD` method

### DIFF
--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -347,18 +347,16 @@ internal class JailbreakChecker {
             "libcycript"
         ]
         
-        for libraryIndex in 0..<_dyld_image_count() {
-            
-            // _dyld_get_image_name returns const char * that needs to be casted to Swift String
-            guard let loadedLibrary = String(validatingUTF8: _dyld_get_image_name(libraryIndex)) else { continue }
-            
-            for suspiciousLibrary in suspiciousLibraries {
-                if loadedLibrary.lowercased().contains(suspiciousLibrary.lowercased()) {
-                    return (false, "Suspicious library loaded: \(loadedLibrary)")
-                }
+        for index in 0..<_dyld_image_count() {
+
+            let imageName = String(cString: _dyld_get_image_name(index))
+
+            // The fastest case insensitive contains check.
+            for library in suspiciousLibraries where imageName.localizedCaseInsensitiveContains(library) {
+                return (false, "Suspicious library loaded: \(imageName)")
             }
         }
-        
+
         return (true, "")
     }
     

--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -318,8 +318,8 @@ internal class JailbreakChecker {
     }
     
     private static func checkDYLD() -> CheckResult {
-        
-        let suspiciousLibraries = [
+
+        let suspiciousLibraries: Set<String> = [
             "SubstrateLoader.dylib",
             "SSLKillSwitch2.dylib",
             "SSLKillSwitch.dylib",

--- a/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
+++ b/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
@@ -58,7 +58,7 @@ internal class ReverseEngineeringToolsChecker {
 
     private static func checkDYLD() -> CheckResult {
 
-        let suspiciousLibraries = [
+        let suspiciousLibraries: Set<String> = [
             "FridaGadget",
             "frida", // Needle injects frida-somerandom.dylib
             "cynject",

--- a/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
+++ b/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
@@ -65,15 +65,13 @@ internal class ReverseEngineeringToolsChecker {
             "libcycript"
         ]
 
-        for libraryIndex in 0..<_dyld_image_count() {
+        for index in 0..<_dyld_image_count() {
 
-            // _dyld_get_image_name returns const char * that needs to be casted to Swift String
-            guard let loadedLibrary = String(validatingUTF8: _dyld_get_image_name(libraryIndex)) else { continue }
+            let imageName = String(cString: _dyld_get_image_name(index))
 
-            for suspiciousLibrary in suspiciousLibraries {
-                if loadedLibrary.lowercased().contains(suspiciousLibrary.lowercased()) {
-                    return (false, "Suspicious library loaded: \(loadedLibrary)")
-                }
+            // The fastest case insensitive contains check.
+            for library in suspiciousLibraries where imageName.localizedCaseInsensitiveContains(library) {
+                return (false, "Suspicious library loaded: \(imageName)")
             }
         }
 


### PR DESCRIPTION
Check DYLD method is executed on the main thread. It is taking around 70 ms, which can result in hangs, hitches or increase in app launch, depending on when the method is called.

The comparison and string initialization improves the performance more than 50 %. In my measurement it was down to 28 ms from 67 ms.

*Configuration used to collect the numbers:*

- iPhone XS
- iOS 17 RC
- Low power mode enabled (it slows down the CPU for 40-50 %)
- Build optimized for speed