### PR TITLE
Removed obsolete `LSApplicationQueriesSchemes` from README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ After adding ISS to your project, you will also need to update your main Info.pl
     <string>sileo</string>
     <string>zbra</string>
     <string>filza</string>
-    <string>activator</string>
 </array>
 ```
 


### PR DESCRIPTION
Since we do not check for `activator://` custom URL scheme from v1.9.11+, I think it is only consistent to remove that from the `LSApplicationQueriesSchemes` and therefore the `README.md`.