### PR TITLE
Search for binding symbols also via `LC_DYLD_CHAINED_FIXUPS `

### DIFF
--- a/IOSSecuritySuite/FishHookChecker.swift
+++ b/IOSSecuritySuite/FishHookChecker.swift
@@ -444,7 +444,6 @@ internal class SymbolFound {
         .advanced(by: `import`.nameOffset)
         .assumingMemoryBound(to: CChar.self)
       let name = String(cString: namePtr + 1)
-      print(`import`.libraryOrdinal, name)
       if name == symbol {
         let ordinal = `import`.libraryOrdinal
         assert(ordinal <= allLoadDylds.count)

--- a/IOSSecuritySuite/FishHookChecker.swift
+++ b/IOSSecuritySuite/FishHookChecker.swift
@@ -765,7 +765,7 @@ private class FishHook {
     
     for tmp in 0..<Int(section.pointee.size)/MemoryLayout<UnsafeMutableRawPointer>.size {
       let curIndirectSym = indirectSymVmAddr.advanced(by: tmp)
-      if curIndirectSym.pointee == INDIRECT_SYMBOL_ABS || curIndirectSym.pointee == INDIRECT_SYMBOL_LOCAL {
+      if curIndirectSym.pointee & UInt32(INDIRECT_SYMBOL_ABS) != 0 || curIndirectSym.pointee & ~UInt32(INDIRECT_SYMBOL_ABS) == INDIRECT_SYMBOL_LOCAL {
         continue
       }
       let curStrTabOff = symtab.advanced(by: Int(curIndirectSym.pointee)).pointee.n_un.n_strx

--- a/IOSSecuritySuite/FishHookChecker.swift
+++ b/IOSSecuritySuite/FishHookChecker.swift
@@ -542,7 +542,7 @@ internal class SymbolFound {
         terminalSize = readUleb128(ptr: &ptr, end: end)
       }
       if terminalSize != 0 {
-        return currentSymbol == targetSymbol ? ptr : nil
+        return currentSymbol == "_" + targetSymbol ? ptr : nil
       }
       
       // children
@@ -568,7 +568,7 @@ internal class SymbolFound {
         // node
         if let nodeSymbol = String(cString: nodeLabel, encoding: .utf8) {
           let tmpCurrentSymbol = currentSymbol + nodeSymbol
-          if !targetSymbol.contains(tmpCurrentSymbol) {
+          if !("_" + targetSymbol).contains(tmpCurrentSymbol) {
             continue
           }
           if nodeOffset != 0 && (start + nodeOffset <= end) {

--- a/IOSSecuritySuite/FishHookChecker.swift
+++ b/IOSSecuritySuite/FishHookChecker.swift
@@ -734,7 +734,7 @@ private class FishHook {
     for segment in [dataCmd, dataConstCmd] {
       guard let segment else { continue }
       for tmp in 0..<segment.pointee.nsects {
-        let curSection = UnsafeMutableRawPointer(dataCmd).advanced(by: MemoryLayout<segment_command_64>.size + MemoryLayout<section_64>.size*Int(tmp)).assumingMemoryBound(to: section_64.self)
+        let curSection = UnsafeMutableRawPointer(segment).advanced(by: MemoryLayout<segment_command_64>.size + MemoryLayout<section_64>.size*Int(tmp)).assumingMemoryBound(to: section_64.self)
 
         // symbol_pointers sections
         if curSection.pointee.flags == S_LAZY_SYMBOL_POINTERS {


### PR DESCRIPTION
Hello, I have implemented the following Issue.
#117 

To check if it works correctly, follow the steps below.
1. Before introducing this pull request, set the `Minimum Deployment` of the app to higher than iOS14
2. Execute the `executeAntiHook` function in the ViewController to check the print operation.
(This function seems to be commented out now.)
(The contents of `myPrint' must be commented out, otherwise it seems to loop infinitely.)
3. Perhaps `print("print has been antiHooked")` doesn't actually print.