### PR TITLE
Fix denyFishHook fatal error

### DIFF
--- a/IOSSecuritySuite/FishHookChecker.swift
+++ b/IOSSecuritySuite/FishHookChecker.swift
@@ -111,17 +111,9 @@ private func readSleb128(ptr: inout UnsafeMutablePointer<UInt8>, end: UnsafeMuta
 internal class FishHookChecker {
   @inline(__always)
   static func denyFishHook(_ symbol: String) {
-    var symbolAddress: UnsafeMutableRawPointer?
-    
     for imgIndex in 0..<_dyld_image_count() {
       if let image = _dyld_get_image_header(imgIndex) {
-        if symbolAddress == nil {
-          _ = SymbolFound.lookSymbol(symbol, at: image, imageSlide: _dyld_get_image_vmaddr_slide(imgIndex), symbolAddress: &symbolAddress)
-        }
-        if let symbolPointer = symbolAddress {
-          var oldMethod: UnsafeMutableRawPointer?
-          FishHook.replaceSymbol(symbol, at: image, imageSlide: _dyld_get_image_vmaddr_slide(imgIndex), newMethod: symbolPointer, oldMethod: &oldMethod)
-        }
+        denyFishHook(symbol, at: image, imageSlide: _dyld_get_image_vmaddr_slide(imgIndex))
       }
     }
   }


### PR DESCRIPTION
There is a fatal error in `denyFishHook(_:)` when the **same** symbolAddress is used multiple times for **different** image/imgIndex.
![denyFishHook fatal error](https://github.com/user-attachments/assets/0255030f-5526-4ad0-9e93-5aa42a698832)

The solution is to query a symbolAddress for **each** image. Which is trivially the code from `denyFishHook(_:at:imageSlide:)` so we can call it directly.

I tested this solution and it solves the crash for me on `FishHookChecker.denyFishHook("dladdr")`.

This probably fixes #60 too.