### PR TITLE
swiftlint lint --fix

### DIFF
--- a/FrameworkClientApp/FishHook.swift
+++ b/FrameworkClientApp/FishHook.swift
@@ -46,19 +46,19 @@ private func replaceSymbolAtImage(
   var dataCmd: UnsafeMutablePointer<segment_command_64>!
   var symtabCmd: UnsafeMutablePointer<symtab_command>!
   var dynamicSymtabCmd: UnsafeMutablePointer<dysymtab_command>!
-  
+
   guard var curCmdPointer = UnsafeMutableRawPointer(bitPattern: UInt(bitPattern: image)+UInt(MemoryLayout<mach_header_64>.size)) else { return }
-  
+
   for _ in 0..<image.pointee.ncmds {
     let curCmd = curCmdPointer.assumingMemoryBound(to: segment_command_64.self)
-    
+
     if curCmd.pointee.cmd == LC_SEGMENT_64 {
       let curCmdNameOffset = MemoryLayout.size(ofValue: curCmd.pointee.cmd) + MemoryLayout.size(ofValue: curCmd.pointee.cmdsize)
       let curCmdNamePointer = curCmdPointer.advanced(by: curCmdNameOffset).assumingMemoryBound(to: Int8.self)
       let curCmdName = String(cString: curCmdNamePointer)
-      if (curCmdName == SEG_LINKEDIT) {
+      if curCmdName == SEG_LINKEDIT {
         linkeditCmd = curCmd
-      } else if (curCmdName == SEG_DATA) {
+      } else if curCmdName == SEG_DATA {
         dataCmd = curCmd
       }
     } else if curCmd.pointee.cmd == LC_SYMTAB {
@@ -66,26 +66,26 @@ private func replaceSymbolAtImage(
     } else if curCmd.pointee.cmd == LC_DYSYMTAB {
       dynamicSymtabCmd = UnsafeMutablePointer<dysymtab_command>(OpaquePointer(curCmd))
     }
-    
+
     curCmdPointer += Int(curCmd.pointee.cmdsize)
   }
-  
+
   if linkeditCmd == nil || symtabCmd == nil || dynamicSymtabCmd == nil || dataCmd == nil {
     return
   }
-  
+
   let linkedBase = slide + Int(linkeditCmd.pointee.vmaddr) - Int(linkeditCmd.pointee.fileoff)
   let symtab = UnsafeMutablePointer<nlist_64>(bitPattern: linkedBase + Int(symtabCmd.pointee.symoff))
   let strtab =  UnsafeMutablePointer<UInt8>(bitPattern: linkedBase + Int(symtabCmd.pointee.stroff))
   let indirectsym = UnsafeMutablePointer<UInt32>(bitPattern: linkedBase + Int(dynamicSymtabCmd.pointee.indirectsymoff))
-  
+
   if symtab == nil || strtab == nil || indirectsym == nil {
     return
   }
-  
+
   for tmp in 0..<dataCmd.pointee.nsects {
     let curSection = UnsafeMutableRawPointer(dataCmd).advanced(by: MemoryLayout<segment_command_64>.size + MemoryLayout<section_64>.size*Int(tmp)).assumingMemoryBound(to: section_64.self)
-    
+
     // symbol_pointers sections
     if curSection.pointee.flags == S_LAZY_SYMBOL_POINTERS {
       replaceSymbolPointerAtSection(curSection, symtab: symtab!, strtab: strtab!, indirectsym: indirectsym!, slide: slide, symbolName: symbol, newMethod: newMethod, oldMethod: &oldMethod)
@@ -109,11 +109,11 @@ private func replaceSymbolPointerAtSection(
 ) {
   let indirectSymVmAddr = indirectsym.advanced(by: Int(section.pointee.reserved1))
   let sectionVmAddr = UnsafeMutablePointer<UnsafeMutableRawPointer>(bitPattern: slide+Int(section.pointee.addr))
-  
+
   if sectionVmAddr == nil {
     return
   }
-  
+
   for tmp in 0..<Int(section.pointee.size)/MemoryLayout<UnsafeMutableRawPointer>.size {
     let curIndirectSym = indirectSymVmAddr.advanced(by: tmp)
     if curIndirectSym.pointee == INDIRECT_SYMBOL_ABS || curIndirectSym.pointee == INDIRECT_SYMBOL_LOCAL {

--- a/IOSSecuritySuite.xcodeproj/project.pbxproj
+++ b/IOSSecuritySuite.xcodeproj/project.pbxproj
@@ -281,6 +281,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		70B0BBC7226F3A5F000CFB39 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/IOSSecuritySuite/DebuggerChecker.swift
+++ b/IOSSecuritySuite/DebuggerChecker.swift
@@ -15,64 +15,64 @@ internal class DebuggerChecker {
     var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
     var size = MemoryLayout<kinfo_proc>.stride
     let sysctlRet = sysctl(&mib, UInt32(mib.count), &kinfo, &size, nil, 0)
-    
+
     if sysctlRet != 0 {
       print("Error occurred when calling sysctl(). The debugger check may not be reliable")
     }
-    
+
     return (kinfo.kp_proc.p_flag & P_TRACED) != 0
   }
-  
+
   static func denyDebugger() {
     // bind ptrace()
     let pointerToPtrace = UnsafeMutableRawPointer(bitPattern: -2)
     let ptracePtr = dlsym(pointerToPtrace, "ptrace")
     typealias PtraceType = @convention(c) (CInt, pid_t, CInt, CInt) -> CInt
     let ptrace = unsafeBitCast(ptracePtr, to: PtraceType.self)
-    
+
     // PT_DENY_ATTACH == 31
     let ptraceRet = ptrace(31, 0, 0, 0)
-    
+
     if ptraceRet != 0 {
       print("Error occured when calling ptrace(). Denying debugger may not be reliable")
     }
   }
-  
+
 #if arch(arm64)
   static func hasBreakpointAt(
     _ functionAddr: UnsafeRawPointer,
     functionSize: vm_size_t?
   ) -> Bool {
     let funcAddr = vm_address_t(UInt(bitPattern: functionAddr))
-    
+
     var vmStart: vm_address_t = funcAddr
     var vmSize: vm_size_t = 0
     let vmRegionInfo = UnsafeMutablePointer<Int32>.allocate(
       capacity: MemoryLayout<vm_region_basic_info_64>.size/4
     )
-    
+
     defer {
       vmRegionInfo.deallocate()
     }
-    
+
     var vmRegionInfoCount: mach_msg_type_number_t = mach_msg_type_number_t(VM_REGION_BASIC_INFO_64)
     var objectName: mach_port_t = 0
-    
+
     let ret = vm_region_64(
       mach_task_self_, &vmStart,
       &vmSize, VM_REGION_BASIC_INFO_64,
       vmRegionInfo, &vmRegionInfoCount,
       &objectName
     )
-    
+
     if ret != KERN_SUCCESS {
       return false
     }
-    
+
     let vmRegion = vmRegionInfo.withMemoryRebound(
       to: vm_region_basic_info_64.self, capacity: 1, { $0 }
     )
-    
+
     if vmRegion.pointee.protection == (VM_PROT_READ | VM_PROT_EXECUTE) {
       let armBreakpointOpcode = 0xe7ffdefe
       let arm64BreakpointOpcode = 0xd4200000
@@ -81,7 +81,7 @@ internal class DebuggerChecker {
       if let size = functionSize, size < judgeSize {
         judgeSize = size
       }
-      
+
       for valueToOffset in 0..<(judgeSize / 4) {
         if (instructionBegin.advanced(
           by: Int(valueToOffset)
@@ -92,31 +92,31 @@ internal class DebuggerChecker {
         }
       }
     }
-    
+
     return false
   }
-  
+
   static func hasWatchpoint() -> Bool {
     var threads: thread_act_array_t?
     var threadCount: mach_msg_type_number_t = 0
     var hasWatchpoint = false
-    
+
     if task_threads(mach_task_self_, &threads, &threadCount) == KERN_SUCCESS {
       var threadStat = arm_debug_state64_t()
       let capacity = MemoryLayout<arm_debug_state64_t>.size/MemoryLayout<natural_t>.size
-      
+
       let threadStatPointer = withUnsafeMutablePointer(to: &threadStat, {
         $0.withMemoryRebound(to: natural_t.self, capacity: capacity, { $0 })
       })
-      
+
       var count = mach_msg_type_number_t(
         MemoryLayout<arm_debug_state64_t>.size/MemoryLayout<UInt32>.size
       )
-      
+
       guard let threads = threads else {
         return false
       }
-      
+
       for threadIndex in 0..<threadCount where thread_get_state(
         threads[Int(threadIndex)],
         ARM_DEBUG_STATE64,
@@ -128,21 +128,21 @@ internal class DebuggerChecker {
         ).pointee.__wvr.0 != 0
         if hasWatchpoint { break }
       }
-      
+
       vm_deallocate(
         mach_task_self_,
         UInt(bitPattern: threads),
         vm_size_t(threadCount * UInt32(MemoryLayout<thread_act_t>.size))
       )
     }
-    
+
     return hasWatchpoint
   }
 #endif
-  
+
   static func isParentPidUnexpected() -> Bool {
     let parentPid: pid_t = getppid()
-    
+
     return parentPid != 1 // LaunchD is pid 1
   }
 }

--- a/IOSSecuritySuite/FishHookChecker.swift
+++ b/IOSSecuritySuite/FishHookChecker.swift
@@ -5,7 +5,6 @@
 //  Created by jintao on 2020/4/24.
 //  Copyright © 2020 wregula. All rights reserved.
 //  https://github.com/TannerJin/anti-fishhook
-
 // swiftlint:disable all
 
 import Foundation
@@ -67,7 +66,7 @@ private func readUleb128(ptr: inout UnsafeMutablePointer<UInt8>, end: UnsafeMuta
   var result: UInt64 = 0
   var bit = 0
   var readNext = true
-  
+
   repeat {
     if ptr == end {
       assert(false, "malformed uleb128")
@@ -90,9 +89,9 @@ private func readSleb128(ptr: inout UnsafeMutablePointer<UInt8>, end: UnsafeMuta
   var result: Int64 = 0
   var bit: Int = 0
   var byte: UInt8
-  
+
   repeat {
-    if (ptr == end) {
+    if ptr == end {
       assert(false, "malformed sleb128")
     }
     byte = ptr.pointee
@@ -100,9 +99,9 @@ private func readSleb128(ptr: inout UnsafeMutablePointer<UInt8>, end: UnsafeMuta
     bit += 7
     ptr += 1
   } while (byte & 0x80) == 1
-  
+
   // sign extend negative numbers
-  if ( (byte & 0x40) != 0 ) {
+  if (byte & 0x40) != 0 {
     result |= -1 << bit
   }
   return result
@@ -117,11 +116,11 @@ internal class FishHookChecker {
       }
     }
   }
-  
+
   @inline(__always)
   static func denyFishHook(_ symbol: String, at image: UnsafePointer<mach_header>, imageSlide slide: Int) {
     var symbolAddress: UnsafeMutableRawPointer?
-    
+
     if SymbolFound.lookSymbol(symbol, at: image, imageSlide: slide, symbolAddress: &symbolAddress), let symbolPointer = symbolAddress {
       var oldMethod: UnsafeMutableRawPointer?
       FishHook.replaceSymbol(symbol, at: image, imageSlide: slide, newMethod: symbolPointer, oldMethod: &oldMethod)
@@ -132,26 +131,26 @@ internal class FishHookChecker {
 // MARK: - SymbolFound
 internal class SymbolFound {
   static private let BindTypeThreadedRebase = 102
-  
+
   @inline(__always)
   static func lookSymbol(_ symbol: String, at image: UnsafePointer<mach_header>, imageSlide slide: Int, symbolAddress: inout UnsafeMutableRawPointer?) -> Bool {
     // target cmd
     var linkeditCmd: UnsafeMutablePointer<segment_command_64>!
     var dyldInfoCmd: UnsafeMutablePointer<dyld_info_command>!
     var allLoadDylds = [String]()
-    
+
     guard var curCmdPointer = UnsafeMutableRawPointer(bitPattern: UInt(bitPattern: image)+UInt(MemoryLayout<mach_header_64>.size)) else {
       return false
     }
     // all cmd
     for _ in 0..<image.pointee.ncmds {
       let curCmd = curCmdPointer.assumingMemoryBound(to: segment_command_64.self)
-      
+
       switch UInt32(curCmd.pointee.cmd) {
       case UInt32(LC_SEGMENT_64):
         let offset = MemoryLayout.size(ofValue: curCmd.pointee.cmd) + MemoryLayout.size(ofValue: curCmd.pointee.cmdsize)
         let curCmdName = String(cString: curCmdPointer.advanced(by: offset).assumingMemoryBound(to: Int8.self))
-        if (curCmdName == SEG_LINKEDIT) {
+        if curCmdName == SEG_LINKEDIT {
           linkeditCmd = curCmd
         }
       case LC_DYLD_INFO_ONLY, UInt32(LC_DYLD_INFO):
@@ -165,34 +164,34 @@ internal class SymbolFound {
       default:
         break
       }
-      
+
       curCmdPointer += Int(curCmd.pointee.cmdsize)
     }
-    
+
     if linkeditCmd == nil || dyldInfoCmd == nil { return false }
     let linkeditBase = UInt64(slide + Int(linkeditCmd.pointee.vmaddr) - Int(linkeditCmd.pointee.fileoff))
-    
+
     // look by LazyBindInfo
     let lazyBindSize = Int(dyldInfoCmd.pointee.lazy_bind_size)
-    if (lazyBindSize > 0) {
+    if lazyBindSize > 0 {
       if let lazyBindInfoCmd = UnsafeMutablePointer<UInt8>(bitPattern: UInt(linkeditBase + UInt64(dyldInfoCmd.pointee.lazy_bind_off))),
          lookLazyBindSymbol(symbol, symbolAddr: &symbolAddress, lazyBindInfoCmd: lazyBindInfoCmd, lazyBindInfoSize: lazyBindSize, allLoadDylds: allLoadDylds) {
         return true
       }
     }
-    
+
     // look by NonLazyBindInfo
     let bindSize = Int(dyldInfoCmd.pointee.bind_size)
-    if (bindSize > 0) {
+    if bindSize > 0 {
       if let bindCmd = UnsafeMutablePointer<UInt8>(bitPattern: UInt(linkeditBase + UInt64(dyldInfoCmd.pointee.bind_off))),
          lookBindSymbol(symbol, symbolAddr: &symbolAddress, bindInfoCmd: bindCmd, bindInfoSize: bindSize, allLoadDylds: allLoadDylds) {
         return true
       }
     }
-    
+
     return false
   }
-  
+
   // LazySymbolBindInfo
   @inline(__always)
   private static func lookLazyBindSymbol(_ symbol: String, symbolAddr: inout UnsafeMutableRawPointer?, lazyBindInfoCmd: UnsafeMutablePointer<UInt8>, lazyBindInfoSize: Int, allLoadDylds: [String]) -> Bool {
@@ -202,12 +201,12 @@ internal class SymbolFound {
     var foundSymbol = false
     var addend = 0
     var type: Int32 = 0
-    
+
   Label: while ptr < lazyBindingInfoEnd {
     let immediate = Int32(ptr.pointee) & BIND_IMMEDIATE_MASK
     let opcode = Int32(ptr.pointee) & BIND_OPCODE_MASK
     ptr += 1
-    
+
     switch opcode {
     case BIND_OPCODE_DONE:
       continue
@@ -225,7 +224,7 @@ internal class SymbolFound {
       // symbol
     case BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM:
       let symbolName = String(cString: ptr + 1)
-      if (symbolName == symbol) {
+      if symbolName == symbol {
         foundSymbol = true
       }
       while ptr.pointee != 0 {
@@ -243,7 +242,7 @@ internal class SymbolFound {
       _ = readUleb128(ptr: &ptr, end: lazyBindingInfoEnd)
       // bind action
     case BIND_OPCODE_DO_BIND:
-      if (foundSymbol) {
+      if foundSymbol {
         break Label
       } else {
         continue
@@ -253,10 +252,10 @@ internal class SymbolFound {
       return false
     }
   }
-    
+
     assert(ordinal <= allLoadDylds.count)
-    
-    if (foundSymbol && ordinal >= 0 && allLoadDylds.count > 0), ordinal <= allLoadDylds.count, type != BindTypeThreadedRebase {
+
+    if foundSymbol && ordinal >= 0 && allLoadDylds.count > 0, ordinal <= allLoadDylds.count, type != BindTypeThreadedRebase {
       let imageName = allLoadDylds[ordinal-1]
       var tmpSymbolAddress: UnsafeMutableRawPointer?
       if lookExportedSymbol(symbol, exportImageName: imageName, symbolAddress: &tmpSymbolAddress), let symbolPointer = tmpSymbolAddress {
@@ -264,10 +263,10 @@ internal class SymbolFound {
         return true
       }
     }
-    
+
     return false
   }
-  
+
   // NonLazySymbolBindInfo
   @inline(__always)
   private static func lookBindSymbol(_ symbol: String, symbolAddr: inout UnsafeMutableRawPointer?, bindInfoCmd: UnsafeMutablePointer<UInt8>, bindInfoSize: Int, allLoadDylds: [String]) -> Bool {
@@ -277,12 +276,12 @@ internal class SymbolFound {
     var foundSymbol = false
     var addend = 0
     var type: Int32 = 0
-    
+
   Label: while ptr < bindingInfoEnd {
     let immediate = Int32(ptr.pointee) & BIND_IMMEDIATE_MASK
     let opcode = Int32(ptr.pointee) & BIND_OPCODE_MASK
     ptr += 1
-    
+
     switch opcode {
     case BIND_OPCODE_DONE:
       break Label
@@ -300,7 +299,7 @@ internal class SymbolFound {
       // symbol
     case BIND_OPCODE_SET_SYMBOL_TRAILING_FLAGS_IMM:
       let symbolName = String(cString: ptr + 1)
-      if (symbolName == symbol) {
+      if symbolName == symbol {
         foundSymbol = true
       }
       while ptr.pointee != 0 {
@@ -318,17 +317,17 @@ internal class SymbolFound {
       _ = readUleb128(ptr: &ptr, end: bindingInfoEnd)
       // do bind action
     case BIND_OPCODE_DO_BIND, BIND_OPCODE_DO_BIND_ADD_ADDR_IMM_SCALED:
-      if (foundSymbol) {
+      if foundSymbol {
         break Label
       }
     case BIND_OPCODE_DO_BIND_ADD_ADDR_ULEB:
-      if (foundSymbol) {
+      if foundSymbol {
         break Label
       } else {
         _ = readUleb128(ptr: &ptr, end: bindingInfoEnd)
       }
     case BIND_OPCODE_DO_BIND_ULEB_TIMES_SKIPPING_ULEB:
-      if (foundSymbol) {
+      if foundSymbol {
         break Label
       } else {
         _ = readUleb128(ptr: &ptr, end: bindingInfoEnd)  // count
@@ -339,7 +338,7 @@ internal class SymbolFound {
       case BIND_SUBOPCODE_THREADED_SET_BIND_ORDINAL_TABLE_SIZE_ULEB:
         _ = readUleb128(ptr: &ptr, end: bindingInfoEnd)
       case BIND_SUBOPCODE_THREADED_APPLY:
-        if (foundSymbol) {
+        if foundSymbol {
           // ImageLoaderMachO::bindLocation case BIND_TYPE_THREADED_REBASE
           assert(false, "maybe bind_type is BIND_TYPE_THREADED_REBASE, don't handle")
           return false
@@ -354,9 +353,9 @@ internal class SymbolFound {
       return false
     }
   }
-    
+
     assert(ordinal <= allLoadDylds.count)
-    if (foundSymbol && ordinal >= 0 && allLoadDylds.count > 0), ordinal <= allLoadDylds.count, type != BindTypeThreadedRebase {
+    if foundSymbol && ordinal >= 0 && allLoadDylds.count > 0, ordinal <= allLoadDylds.count, type != BindTypeThreadedRebase {
       let imageName = allLoadDylds[ordinal-1]
       var tmpSymbolAddress: UnsafeMutableRawPointer?
       if lookExportedSymbol(symbol, exportImageName: imageName, symbolAddress: &tmpSymbolAddress), let symbolPointer = tmpSymbolAddress {
@@ -364,30 +363,30 @@ internal class SymbolFound {
         return true
       }
     }
-    
+
     return false
   }
-  
+
   // ExportSymbol
   @inline(__always)
   private static func lookExportedSymbol(_ symbol: String, exportImageName: String, symbolAddress: inout UnsafeMutableRawPointer?) -> Bool {
     var rpathImage: String?
     // @rpath
-    if (exportImageName.contains("@rpath")) {
+    if exportImageName.contains("@rpath") {
       rpathImage = exportImageName.components(separatedBy: "/").last
     }
-    
+
     for index in 0..<_dyld_image_count() {
       // imageName
       let currentImageName = String(cString: _dyld_get_image_name(index))
       if let tmpRpathImage = rpathImage {
-        if (!currentImageName.contains(tmpRpathImage)) {
+        if !currentImageName.contains(tmpRpathImage) {
           continue
         }
-      } else if (String(cString: _dyld_get_image_name(index)) != exportImageName) {
+      } else if String(cString: _dyld_get_image_name(index)) != exportImageName {
         continue
       }
-      
+
       if let pointer = _lookExportedSymbol(symbol, image: _dyld_get_image_header(index), imageSlide: _dyld_get_image_vmaddr_slide(index)) {
         // found
         symbolAddress = UnsafeMutableRawPointer(mutating: pointer)
@@ -395,13 +394,13 @@ internal class SymbolFound {
       } else {
         // not found, look at ReExport dylibs
         var allReExportDylibs = [String]()
-        
+
         if let currentImage = _dyld_get_image_header(index),
            var curCmdPointer = UnsafeMutableRawPointer(bitPattern: UInt(bitPattern: currentImage)+UInt(MemoryLayout<mach_header_64>.size)) {
-          
+
           for _ in 0..<currentImage.pointee.ncmds {
             let curCmd = curCmdPointer.assumingMemoryBound(to: segment_command_64.self)
-            if (curCmd.pointee.cmd == LC_REEXPORT_DYLIB) {
+            if curCmd.pointee.cmd == LC_REEXPORT_DYLIB {
               let reExportDyldCmd = curCmdPointer.assumingMemoryBound(to: dylib_command.self)
               let nameOffset = Int(reExportDyldCmd.pointee.dylib.name.offset)
               let namePointer = curCmdPointer.advanced(by: nameOffset).assumingMemoryBound(to: Int8.self)
@@ -411,7 +410,7 @@ internal class SymbolFound {
             curCmdPointer += Int(curCmd.pointee.cmdsize)
           }
         }
-        
+
         for reExportDyld in allReExportDylibs where lookExportedSymbol(symbol, exportImageName: reExportDyld, symbolAddress: &symbolAddress) {
           return true
         }
@@ -419,10 +418,10 @@ internal class SymbolFound {
         return false
       }
     }
-    
+
     return false
   }
-  
+
   // look export symbol by export trie
   @inline(__always)
   static private func _lookExportedSymbol(_ symbol: String, image: UnsafePointer<mach_header>, imageSlide slide: Int) -> UnsafeMutableRawPointer? {
@@ -430,19 +429,19 @@ internal class SymbolFound {
     var linkeditCmd: UnsafeMutablePointer<segment_command_64>!
     var dyldInfoCmd: UnsafeMutablePointer<dyld_info_command>!
     var exportCmd: UnsafeMutablePointer<linkedit_data_command>!
-    
+
     guard var curCmdPointer = UnsafeMutableRawPointer(bitPattern: UInt(bitPattern: image)+UInt(MemoryLayout<mach_header_64>.size)) else {
       return nil
     }
     // cmd
     for _ in 0..<image.pointee.ncmds {
       let curCmd = curCmdPointer.assumingMemoryBound(to: segment_command_64.self)
-      
+
       switch UInt32(curCmd.pointee.cmd) {
       case UInt32(LC_SEGMENT_64):
         let offset = MemoryLayout.size(ofValue: curCmd.pointee.cmd) + MemoryLayout.size(ofValue: curCmd.pointee.cmdsize)
         let curCmdName = String(cString: curCmdPointer.advanced(by: offset).assumingMemoryBound(to: Int8.self))
-        if (curCmdName == SEG_LINKEDIT) {
+        if curCmdName == SEG_LINKEDIT {
           linkeditCmd = curCmd
         }
       case LC_DYLD_INFO_ONLY, UInt32(LC_DYLD_INFO):
@@ -452,47 +451,47 @@ internal class SymbolFound {
       default:
         break
       }
-      
+
       curCmdPointer += Int(curCmd.pointee.cmdsize)
     }
-    
+
     // export trie info
     let hasDyldInfo = dyldInfoCmd != nil && dyldInfoCmd.pointee.export_size != 0
     let hasExportTrie = exportCmd != nil && exportCmd.pointee.datasize != 0
     if linkeditCmd == nil || (!hasDyldInfo && !hasExportTrie) {
       return nil
     }
-    
+
     let linkeditBase = Int(slide + Int(linkeditCmd.pointee.vmaddr) - Int(linkeditCmd.pointee.fileoff))
     let exportOff = hasExportTrie ? exportCmd.pointee.dataoff : dyldInfoCmd.pointee.export_off
     let exportSize = hasExportTrie ? exportCmd.pointee.datasize : dyldInfoCmd.pointee.export_size
-    
+
     guard let exportedInfo = UnsafeMutableRawPointer(bitPattern: linkeditBase + Int(exportOff))?.assumingMemoryBound(to: UInt8.self) else { return nil }
-    
+
     let start = exportedInfo
     let end = exportedInfo + Int(exportSize)
-    
+
     // export symbol location
     if var symbolLocation = lookExportedSymbolByTrieWalk(targetSymbol: symbol, start: start, end: end, currentLocation: start, currentSymbol: "") {
       let flags = readUleb128(ptr: &symbolLocation, end: end)
-      
+
       let returnSymbolAddress = { () -> UnsafeMutableRawPointer in
         let machO = image.withMemoryRebound(to: Int8.self, capacity: 1, { $0 })
         let symbolAddress = machO.advanced(by: Int(readUleb128(ptr: &symbolLocation, end: end)))
         return UnsafeMutableRawPointer(mutating: symbolAddress)
       }
-      
+
       switch flags & UInt64(EXPORT_SYMBOL_FLAGS_KIND_MASK) {
       case UInt64(EXPORT_SYMBOL_FLAGS_KIND_REGULAR):
         // runResolver is false by bind or lazyBind
         return returnSymbolAddress()
       case UInt64(EXPORT_SYMBOL_FLAGS_KIND_THREAD_LOCAL):
-        if (flags & UInt64(EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER) != 0) {
+        if flags & UInt64(EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER) != 0 {
           return nil
         }
         return returnSymbolAddress()
       case UInt64(EXPORT_SYMBOL_FLAGS_KIND_ABSOLUTE):
-        if (flags & UInt64(EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER) != 0) {
+        if flags & UInt64(EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER) != 0 {
           return nil
         }
         return UnsafeMutableRawPointer(bitPattern: UInt(readUleb128(ptr: &symbolLocation, end: end)))
@@ -500,15 +499,15 @@ internal class SymbolFound {
         break
       }
     }
-    
+
     return nil
   }
-  
+
   // ExportSymbol
   @inline(__always)
   static private func lookExportedSymbolByTrieWalk(targetSymbol: String, start: UnsafeMutablePointer<UInt8>, end: UnsafeMutablePointer<UInt8>, currentLocation location: UnsafeMutablePointer<UInt8>, currentSymbol: String) -> UnsafeMutablePointer<UInt8>? {
     var ptr = location
-    
+
     while ptr <= end {
       // terminalSize
       var terminalSize = UInt64(ptr.pointee)
@@ -520,7 +519,7 @@ internal class SymbolFound {
       if terminalSize != 0 {
         return currentSymbol == targetSymbol ? ptr : nil
       }
-      
+
       // children
       let children = ptr.advanced(by: Int(terminalSize))
       if children >= end {
@@ -529,18 +528,18 @@ internal class SymbolFound {
       }
       let childrenCount = children.pointee
       ptr = children + 1
-      
+
       // nodes
       for _ in 0..<childrenCount {
         let nodeLabel = ptr.withMemoryRebound(to: CChar.self, capacity: 1, { $0 })
-        
+
         // node offset
         while ptr.pointee != 0 {
           ptr += 1
         }
         ptr += 1  // = "00"
         let nodeOffset = Int(readUleb128(ptr: &ptr, end: end))
-        
+
         // node
         if let nodeSymbol = String(cString: nodeLabel, encoding: .utf8) {
           let tmpCurrentSymbol = currentSymbol + nodeSymbol
@@ -570,7 +569,7 @@ private class FishHook {
                                         oldMethod: inout UnsafeMutableRawPointer?) {
     replaceSymbolAtImage(image, imageSlide: slide, symbol: symbol, newMethod: newMethod, oldMethod: &oldMethod)
   }
-  
+
   @inline(__always)
   private static func replaceSymbolAtImage(_ image: UnsafePointer<mach_header>,
                                            imageSlide slide: Int,
@@ -582,12 +581,12 @@ private class FishHook {
     var dataConstCmd: UnsafeMutablePointer<segment_command_64>!
     var symtabCmd: UnsafeMutablePointer<symtab_command>!
     var dynamicSymtabCmd: UnsafeMutablePointer<dysymtab_command>!
-    
+
     guard var curCmdPointer = UnsafeMutableRawPointer(bitPattern: UInt(bitPattern: image)+UInt(MemoryLayout<mach_header_64>.size)) else { return }
-    
+
     for _ in 0..<image.pointee.ncmds {
       let curCmd = curCmdPointer.assumingMemoryBound(to: segment_command_64.self)
-      
+
       if curCmd.pointee.cmd == LC_SEGMENT_64 {
         let curCmdNameOffset = MemoryLayout.size(ofValue: curCmd.pointee.cmd) + MemoryLayout.size(ofValue: curCmd.pointee.cmdsize)
         let curCmdNamePointer = curCmdPointer.advanced(by: curCmdNameOffset).assumingMemoryBound(to: Int8.self)
@@ -606,23 +605,23 @@ private class FishHook {
       } else if curCmd.pointee.cmd == LC_DYSYMTAB {
         dynamicSymtabCmd = UnsafeMutablePointer<dysymtab_command>(OpaquePointer(curCmd))
       }
-      
+
       curCmdPointer += Int(curCmd.pointee.cmdsize)
     }
-    
+
     if linkeditCmd == nil || symtabCmd == nil || dynamicSymtabCmd == nil || (dataCmd == nil && dataConstCmd == nil) {
       return
     }
-    
+
     let linkedBase = slide + Int(linkeditCmd.pointee.vmaddr) - Int(linkeditCmd.pointee.fileoff)
     let symtab = UnsafeMutablePointer<nlist_64>(bitPattern: linkedBase + Int(symtabCmd.pointee.symoff))
     let strtab =  UnsafeMutablePointer<UInt8>(bitPattern: linkedBase + Int(symtabCmd.pointee.stroff))
     let indirectsym = UnsafeMutablePointer<UInt32>(bitPattern: linkedBase + Int(dynamicSymtabCmd.pointee.indirectsymoff))
-    
+
     if symtab == nil || strtab == nil || indirectsym == nil {
       return
     }
-    
+
     for segment in [dataCmd, dataConstCmd] {
       guard let segment else { continue }
       for tmp in 0..<segment.pointee.nsects {
@@ -638,7 +637,7 @@ private class FishHook {
       }
     }
   }
-  
+
   @inline(__always)
   private static func replaceSymbolPointerAtSection(_ section: UnsafeMutablePointer<section_64>,
                                                     symtab: UnsafeMutablePointer<nlist_64>,
@@ -650,11 +649,11 @@ private class FishHook {
                                                     oldMethod: inout UnsafeMutableRawPointer?) {
     let indirectSymVmAddr = indirectsym.advanced(by: Int(section.pointee.reserved1))
     let sectionVmAddr = UnsafeMutablePointer<UnsafeMutableRawPointer>(bitPattern: slide+Int(section.pointee.addr))
-    
+
     if sectionVmAddr == nil {
       return
     }
-    
+
     for tmp in 0..<Int(section.pointee.size)/MemoryLayout<UnsafeMutableRawPointer>.size {
       let curIndirectSym = indirectSymVmAddr.advanced(by: tmp)
       if curIndirectSym.pointee == INDIRECT_SYMBOL_ABS || curIndirectSym.pointee == INDIRECT_SYMBOL_LOCAL {
@@ -662,7 +661,7 @@ private class FishHook {
       }
       let curStrTabOff = symtab.advanced(by: Int(curIndirectSym.pointee)).pointee.n_un.n_strx
       let curSymbolName = strtab.advanced(by: Int(curStrTabOff+1))
-      
+
       if String(cString: curSymbolName) == symbolName {
         oldMethod = sectionVmAddr!.advanced(by: tmp).pointee
         let err = vm_protect(

--- a/IOSSecuritySuite/IOSSecuritySuite.swift
+++ b/IOSSecuritySuite/IOSSecuritySuite.swift
@@ -5,7 +5,7 @@
 //  Created by wregula on 23/04/2019.
 //  Copyright © 2019 wregula. All rights reserved.
 //
-// swiftlint:disable inclusive_language
+// swiftlint:disable file_length
 
 import Foundation
 import MachO
@@ -24,7 +24,7 @@ public class IOSSecuritySuite {
   public static func amIJailbroken() -> Bool {
     return JailbreakChecker.amIJailbroken()
   }
-  
+
   /// This type method is used to determine the jailbreak status with a message which jailbreak indicator was detected
   ///
   /// Usage example
@@ -42,7 +42,7 @@ public class IOSSecuritySuite {
   public static func amIJailbrokenWithFailMessage() -> (jailbroken: Bool, failMessage: String) {
     return JailbreakChecker.amIJailbrokenWithFailMessage()
   }
-  
+
   /// This type method is used to determine the jailbreak status with a list of failed checks
   ///
   /// Usage example
@@ -59,7 +59,7 @@ public class IOSSecuritySuite {
                                                          failedChecks: [FailedCheckType]) {
     return JailbreakChecker.amIJailbrokenWithFailedChecks()
   }
-  
+
   /// This type method is used to determine if application is run in emulator
   ///
   /// Usage example
@@ -70,7 +70,7 @@ public class IOSSecuritySuite {
   public static func amIRunInEmulator() -> Bool {
     return EmulatorChecker.amIRunInEmulator()
   }
-  
+
   /// This type method is used to determine if application is being debugged
   ///
   /// Usage example
@@ -81,7 +81,7 @@ public class IOSSecuritySuite {
   public static func amIDebugged() -> Bool {
     return DebuggerChecker.amIDebugged()
   }
-  
+
   /// This type method is used to deny debugger and improve the application resiliency
   ///
   /// Usage example
@@ -91,7 +91,7 @@ public class IOSSecuritySuite {
   public static func denyDebugger() {
     return DebuggerChecker.denyDebugger()
   }
-  
+
   /// This method is used to determine if application was launched by something
   /// other than LaunchD (i.e. the app was launched by a debugger)
   ///
@@ -103,7 +103,7 @@ public class IOSSecuritySuite {
   public static func isParentPidUnexpected() -> Bool {
     return DebuggerChecker.isParentPidUnexpected()
   }
-  
+
   /// This type method is used to determine if application has been tampered with
   ///
   /// Usage example
@@ -123,7 +123,7 @@ public class IOSSecuritySuite {
   public static func amITampered(_ checks: [FileIntegrityCheck]) -> FileIntegrityCheckResult {
     return IntegrityChecker.amITampered(checks)
   }
-  
+
   /// This type method is used to determine if there are any popular reverse engineering tools installed on the device
   ///
   /// Usage example
@@ -134,7 +134,7 @@ public class IOSSecuritySuite {
   public static func amIReverseEngineered() -> Bool {
     return ReverseEngineeringToolsChecker.amIReverseEngineered()
   }
-  
+
   /// This type method is used to determine the reverse engineered status with a list of failed checks
   ///
   /// Usage example
@@ -151,7 +151,7 @@ public class IOSSecuritySuite {
                                                                 failedChecks: [FailedCheckType]) {
     return ReverseEngineeringToolsChecker.amIReverseEngineeredWithFailedChecks()
   }
-  
+
   /// This type method is used to determine if `objc call` has been RuntimeHooked by for example `Flex`
   ///
   /// Usage example
@@ -176,7 +176,7 @@ public class IOSSecuritySuite {
      renamed: "amIRuntimeHooked(dyldAllowList:detectionClass:selector:isClassMethod:)"
   )
   public static func amIRuntimeHooked(
-    dyldWhiteList: [String],
+    dyldWhiteList: [String],// swiftlint:disable:this inclusive_language
     detectionClass: AnyClass,
     selector: Selector,
     isClassMethod: Bool
@@ -188,7 +188,7 @@ public class IOSSecuritySuite {
       isClassMethod: isClassMethod
     )
   }
-  
+
   /// This type method is used to determine if `objc call` has been RuntimeHooked by for example `Flex`
   ///
   /// Usage example
@@ -221,7 +221,7 @@ public class IOSSecuritySuite {
       isClassMethod: isClassMethod
     )
   }
-  
+
   /// This type method is used to determine if  HTTP proxy was set in the iOS Settings.
   ///
   /// Usage example
@@ -232,7 +232,7 @@ public class IOSSecuritySuite {
   public static func amIProxied() -> Bool {
     return ProxyChecker.amIProxied()
   }
-  
+
   /// This type method is used to determine if the iDevice has lockdown mode turned on.
   ///
   /// Usage example
@@ -265,7 +265,7 @@ public extension IOSSecuritySuite {
   static func amIMSHooked(_ functionAddress: UnsafeMutableRawPointer) -> Bool {
     return MSHookFunctionChecker.amIMSHooked(functionAddress)
   }
-  
+
   /// This type method is used to get original `function_address` which has been hooked by  `MSHook`
   ///
   /// Usage example
@@ -287,7 +287,7 @@ public extension IOSSecuritySuite {
   static func denyMSHook(_ functionAddress: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
     return MSHookFunctionChecker.denyMSHook(functionAddress)
   }
-  
+
   /// This type method is used to rebind `symbol` which has been hooked by `fishhook`
   ///
   /// Usage example
@@ -301,7 +301,7 @@ public extension IOSSecuritySuite {
   static func denySymbolHook(_ symbol: String) {
     FishHookChecker.denyFishHook(symbol)
   }
-  
+
   /// This type method is used to rebind `symbol` which has been hooked  at one of image by `fishhook`
   ///
   /// Usage example
@@ -323,7 +323,7 @@ public extension IOSSecuritySuite {
   ) {
     FishHookChecker.denyFishHook(symbol, at: image, imageSlide: slide)
   }
-  
+
   /// This type method is used to get the SHA256 hash value of the executable file in a specified image
   ///
   /// - Attention: **Dylib only.** This means you should set Mach-O type as `Dynamic Library` in your *Build Settings*.
@@ -346,7 +346,7 @@ public extension IOSSecuritySuite {
   static func getMachOFileHashValue(_ target: IntegrityCheckerImageTarget = .default) -> String? {
     return IntegrityChecker.getMachOFileHashValue(target)
   }
-  
+
   /// This type method is used to find all loaded dylibs in the specified image
   ///
   /// - Attention: **Dylib only.** This means you should set Mach-O type as `Dynamic Library` in your /*Build Settings*.
@@ -363,7 +363,7 @@ public extension IOSSecuritySuite {
   static func findLoadedDylibs(_ target: IntegrityCheckerImageTarget = .default) -> [String]? {
     return IntegrityChecker.findLoadedDylibs(target)
   }
-  
+
   /// This type method is used to determine if there are any breakpoints at the function
   ///
   /// Usage example
@@ -382,7 +382,7 @@ public extension IOSSecuritySuite {
   static func hasBreakpointAt(_ functionAddr: UnsafeRawPointer, functionSize: vm_size_t?) -> Bool {
     return DebuggerChecker.hasBreakpointAt(functionAddr, functionSize: functionSize)
   }
-  
+
   /// This type method is used to detect if a watchpoint is being used.
   /// A watchpoint is a type of breakpoint that 'watches' an area of memory associated with a data item.
   ///
@@ -403,4 +403,3 @@ public extension IOSSecuritySuite {
   }
 }
 #endif
-// swiftlint:enable inclusive_language

--- a/IOSSecuritySuite/IntegrityChecker.swift
+++ b/IOSSecuritySuite/IntegrityChecker.swift
@@ -19,11 +19,11 @@ protocol Explainable {
 public enum FileIntegrityCheck {
   /// Compare current bundleID with a specified bundleID.
   case bundleID(String)
-  
+
   /// Compare current hash value(SHA256 hex string) of `embedded.mobileprovision` with a specified hash value.
   /// Use command `"shasum -a 256 /path/to/embedded.mobileprovision"` to get SHA256 value on your macOS.
   case mobileProvision(String)
-  
+
   /// Compare current hash value(SHA256 hex string) of executable file with a specified (Image Name, Hash Value).
   /// Only work on dynamic library and arm64.
   case machO(String, String)
@@ -50,7 +50,7 @@ internal class IntegrityChecker {
   static func amITampered(_ checks: [FileIntegrityCheck]) -> FileIntegrityCheckResult {
     var hitChecks: [FileIntegrityCheck] = []
     var result = false
-    
+
     for check in checks {
       switch check {
       case .bundleID(let exceptedBundleID):
@@ -70,27 +70,27 @@ internal class IntegrityChecker {
         }
       }
     }
-    
+
     return (result, hitChecks)
   }
-  
+
   private static func checkBundleID(_ expectedBundleID: String) -> Bool {
     if expectedBundleID != Bundle.main.bundleIdentifier {
       return true
     }
-    
+
     return false
   }
-  
+
   private static func checkMobileProvision(_ expectedSha256Value: String) -> Bool {
     guard let path = Bundle.main.path(
       forResource: "embedded", ofType: "mobileprovision"
     ) else {
       return false
     }
-    
+
     let url = URL(fileURLWithPath: path)
-    
+
     if FileManager.default.fileExists(atPath: url.path) {
       if let data = FileManager.default.contents(atPath: url.path) {
         // Hash: SHA256
@@ -98,16 +98,16 @@ internal class IntegrityChecker {
         data.withUnsafeBytes {
           _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
         }
-        
+
         if Data(hash).hexEncodedString() != expectedSha256Value {
           return true
         }
       }
     }
-    
+
     return false
   }
-  
+
   private static func checkMachO(_ imageName: String, with expectedSha256Value: String) -> Bool {
 #if arch(arm64)
     if let hashValue = getMachOFileHashValue(.custom(imageName)), hashValue != expectedSha256Value {
@@ -123,7 +123,7 @@ internal class IntegrityChecker {
 public enum IntegrityCheckerImageTarget {
   /// Default image
   case `default`
-  
+
   /// Custom image with a specified name
   case custom(String)
 }
@@ -138,7 +138,7 @@ extension IntegrityChecker {
       return MachOParse().getTextSectionDataSHA256Value()
     }
   }
-  
+
   // Find loaded dylib with a specified image target
   static func findLoadedDylibs(_ target: IntegrityCheckerImageTarget = .default) -> [String]? {
     switch target {
@@ -165,7 +165,7 @@ private struct SegmentInfo {
 @inline(__always)
 private func convert16BitInt8TupleToString(int8Tuple: (Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)) -> String {
   let mirror = Mirror(reflecting: int8Tuple)
-  
+
   return mirror.children.map {
     String(UnicodeScalar(UInt8($0.value as! Int8)))
   }.joined().replacingOccurrences(of: "\0", with: "")
@@ -174,17 +174,17 @@ private func convert16BitInt8TupleToString(int8Tuple: (Int8, Int8, Int8, Int8, I
 private class MachOParse {
   private var base: UnsafePointer<mach_header>?
   private var slide: Int?
-  
+
   init() {
     base    = _dyld_get_image_header(0)
     slide   = _dyld_get_image_vmaddr_slide(0)
   }
-  
+
   init(header: UnsafePointer<mach_header>, slide: Int) {
     self.base   = header
     self.slide  = slide
   }
-  
+
   init(imageName: String) {
     for index in 0..<_dyld_image_count() {
       if let cImgName = _dyld_get_image_name(index), String(cString: cImgName).contains(imageName),
@@ -194,27 +194,27 @@ private class MachOParse {
       }
     }
   }
-  
+
   private func vm2real(_ vmaddr: UInt64) -> UInt64? {
     guard let slide = slide else {
       return nil
     }
-    
+
     return UInt64(slide) + vmaddr
   }
-  
+
   func findLoadedDylibs() -> [String]? {
     guard let header = base else {
       return nil
     }
-    
+
     guard var curCmd = UnsafeMutablePointer<segment_command_64>(bitPattern: UInt(bitPattern: header) + UInt(MemoryLayout<mach_header_64>.size)) else {
       return nil
     }
-    
+
     var array: [String] = Array()
     var segCmd: UnsafeMutablePointer<segment_command_64>!
-    
+
     for _ in 0..<header.pointee.ncmds {
       segCmd = curCmd
       if segCmd.pointee.cmd == LC_LOAD_DYLIB || segCmd.pointee.cmd == LC_LOAD_WEAK_DYLIB {
@@ -224,62 +224,62 @@ private class MachOParse {
           array.append(dylibName)
         }
       }
-      
+
       curCmd = UnsafeMutableRawPointer(curCmd).advanced(by: Int(curCmd.pointee.cmdsize)).assumingMemoryBound(to: segment_command_64.self)
     }
-    
+
     return array
   }
-  
+
   func findSegment(_ segname: String) -> SegmentInfo? {
     guard let header = base else {
       return nil
     }
-    
+
     guard var curCmd = UnsafeMutablePointer<segment_command_64>(
       bitPattern: UInt(bitPattern: header) + UInt(MemoryLayout<mach_header_64>.size)
     ) else {
       return nil
     }
-    
+
     var segCmd: UnsafeMutablePointer<segment_command_64>!
-    
+
     for _ in 0..<header.pointee.ncmds {
       segCmd = curCmd
       if segCmd.pointee.cmd == LC_SEGMENT_64 {
         let segName = convert16BitInt8TupleToString(int8Tuple: segCmd.pointee.segname)
-        
+
         if segname == segName,
            let vmaddr = vm2real(segCmd.pointee.vmaddr) {
           let segmentInfo = SegmentInfo(segment: segCmd, addr: vmaddr)
           return segmentInfo
         }
       }
-      
+
       curCmd = UnsafeMutableRawPointer(curCmd).advanced(by: Int(curCmd.pointee.cmdsize)).assumingMemoryBound(to: segment_command_64.self)
     }
-    
+
     return nil
   }
-  
+
   func findSection(_ segname: String, secname: String) -> SectionInfo? {
     guard let header = base else {
       return nil
     }
-    
+
     guard var curCmd = UnsafeMutablePointer<segment_command_64>(
       bitPattern: UInt(bitPattern: header) + UInt(MemoryLayout<mach_header_64>.size)
     ) else {
       return nil
     }
-    
+
     var segCmd: UnsafeMutablePointer<segment_command_64>!
-    
+
     for _ in 0..<header.pointee.ncmds {
       segCmd = curCmd
       if segCmd.pointee.cmd == LC_SEGMENT_64 {
         let segName = convert16BitInt8TupleToString(int8Tuple: segCmd.pointee.segname)
-        
+
         if segname == segName {
           for sectionID in 0..<segCmd.pointee.nsects {
             guard let sect = UnsafeMutablePointer<section_64>(
@@ -291,9 +291,9 @@ private class MachOParse {
             ) else {
               return nil
             }
-            
+
             let secName = convert16BitInt8TupleToString(int8Tuple: sect.pointee.sectname)
-            
+
             if secName == secname,
                let addr = vm2real(sect.pointee.addr) {
               let sectionInfo = SectionInfo(section: sect, addr: addr)
@@ -302,28 +302,28 @@ private class MachOParse {
           }
         }
       }
-      
+
       curCmd = UnsafeMutableRawPointer(curCmd).advanced(by: Int(curCmd.pointee.cmdsize)).assumingMemoryBound(to: segment_command_64.self)
     }
-    
+
     return nil
   }
-  
+
   func getTextSectionDataSHA256Value() -> String? {
     guard let sectionInfo = findSection(SEG_TEXT, secname: SECT_TEXT) else {
       return nil
     }
-    
+
     guard let startAddr = UnsafeMutablePointer<Any>(bitPattern: Int(sectionInfo.addr)) else {
       return nil
     }
-    
+
     let size = sectionInfo.section.pointee.size
-    
+
     // Hash: SHA256
     var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
     _ = CC_SHA256(startAddr, CC_LONG(size), &hash)
-    
+
     return Data(hash).hexEncodedString()
   }
 }

--- a/IOSSecuritySuite/MSHookFunctionChecker.swift
+++ b/IOSSecuritySuite/MSHookFunctionChecker.swift
@@ -77,7 +77,7 @@ internal class MSHookFunctionChecker {
     case adrp_x17(pageBase: UInt64)
     case add_x17(pageOffset: UInt64)
     case br_x17
-    
+
     @inline(__always)
     static fileprivate func translateInstruction(
       at functionAddr: UnsafeMutableRawPointer
@@ -138,7 +138,7 @@ internal class MSHookFunctionChecker {
       }
       return nil
     }
-    
+
     // pageBase
     @inline(__always)
     static private func getAdrpPageBase(_ functionAddr: UnsafeMutableRawPointer) -> UInt64 {
@@ -160,7 +160,7 @@ internal class MSHookFunctionChecker {
       return UInt64(Int64(pcBase) + singExtend(imm))
     }
   }
-  
+
   @inline(__always)
   static func amIMSHooked(_ functionAddr: UnsafeMutableRawPointer) -> Bool {
     guard let firstInstruction = MSHookInstruction.translateInstruction(at: functionAddr) else {
@@ -185,7 +185,7 @@ internal class MSHookFunctionChecker {
       return false
     }
   }
-  
+
   @inline(__always)
   static func denyMSHook(_ functionAddr: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
     if !amIMSHooked(functionAddr) {
@@ -219,13 +219,13 @@ internal class MSHookFunctionChecker {
     var vmRegionSize: vm_size_t = 0
     var vmRegionInfoCount: mach_msg_type_number_t = mach_msg_type_number_t(VM_REGION_BASIC_INFO_64)
     var objectName: mach_port_t = 0
-    
+
     while true {
       if vmRegionAddress == 0 {
         // False address
         return nil
       }
-      
+
       // Get VM region of designated address
       if vm_region_64(
         mach_task_self_,
@@ -239,18 +239,18 @@ internal class MSHookFunctionChecker {
         // End of vm_regions or something wrong
         return nil
       }
-      
+
       let regionInfo = UnsafeMutableRawPointer(vmRegionInfo).assumingMemoryBound(
         to: vm_region_basic_info_64.self
       )
-      
+
       // vm region of code
       if regionInfo.pointee.protection != (VM_PROT_READ | VM_PROT_EXECUTE) {
         // Memory protection level of executable region is always READ + EXECUTE
         vmRegionAddress += vmRegionSize
         continue
       }
-      
+
       // ldr (Mobile Substrate)
       if case .ldr_x16 = firstInstruction {
         // Current vm region instruction address
@@ -259,7 +259,7 @@ internal class MSHookFunctionChecker {
         var vmRegionInstAddr = vmRegionAddress
         // Last address of current vm region
         let vmRegionEndAddress = vmRegionAddress + vmRegionSize
-        
+
         // Unlike substitute, When using substrate, branching address may resides anywhere in vm region.
         // So every region must be investigated to check whether it contains original function address.
         while vmRegionEndAddress >= vmRegionInstAddr {
@@ -269,12 +269,12 @@ internal class MSHookFunctionChecker {
           ) else {
             continue
           }
-          
+
           if UInt(bitPattern: instructionAddr.pointee) == 0 {
             vmRegionProcedureAddr = vmRegionInstAddr + 4
             continue
           }
-          
+
           if case .ldr_x16 = MSHookInstruction.translateInstruction(
             at: instructionAddr
           ), case .br_x16 = MSHookInstruction.translateInstruction(

--- a/IOSSecuritySuite/ModesChecker.swift
+++ b/IOSSecuritySuite/ModesChecker.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 internal class ModesChecker {
-  
+
   static func amIInLockdownMode() -> Bool {
     return UserDefaults.standard.bool(forKey: "LDMGlobalEnabled")
   }
-  
+
 }

--- a/IOSSecuritySuite/ProxyChecker.swift
+++ b/IOSSecuritySuite/ProxyChecker.swift
@@ -13,17 +13,17 @@ internal class ProxyChecker {
         guard let unmanagedSettings = CFNetworkCopySystemProxySettings() else {
             return false
         }
-        
+
         let settingsOptional = unmanagedSettings.takeRetainedValue() as? [String: Any]
-        
+
         guard  let settings = settingsOptional else {
             return false
         }
-        
-        if(considerVPNConnectionAsProxy) {
+
+        if considerVPNConnectionAsProxy {
             if let scoped = settings["__SCOPED__"] as? [String: Any] {
                 for interface in scoped.keys {
-                    
+
                     let names = [
                         "tap",
                         "tun",
@@ -31,17 +31,17 @@ internal class ProxyChecker {
                         "ipsec",
                         "utun"
                     ]
-                    
-                    for name in names {
-                        if(interface.contains(name)) {
-                            print("detected: \(interface)")
-                            return true
-                        }
+
+                    if names.contains(where: { name in
+                        interface.contains(name)
+                    }) {
+                        print("detected: \(interface)")
+                        return true
                     }
                 }
             }
         }
-        
+
         return (settings.keys.contains("HTTPProxy") || settings.keys.contains("HTTPSProxy"))
     }
 }

--- a/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
+++ b/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
@@ -11,27 +11,27 @@ import MachO // dyld
 
 internal class ReverseEngineeringToolsChecker {
   typealias CheckResult = (passed: Bool, failMessage: String)
-  
+
   struct ReverseEngineeringToolsStatus {
     let passed: Bool
     let failedChecks: [FailedCheckType]
   }
-  
+
   static func amIReverseEngineered() -> Bool {
     return !performChecks().passed
   }
-  
+
   static func amIReverseEngineeredWithFailedChecks() -> (reverseEngineered: Bool,
                                                          failedChecks: [FailedCheckType]) {
     let status = performChecks()
     return (!status.passed, status.failedChecks)
   }
-  
+
   private static func performChecks() -> ReverseEngineeringToolsStatus {
     var passed = true
     var result: CheckResult = (true, "")
     var failedChecks: [FailedCheckType] = []
-    
+
     for check in FailedCheck.allCases {
       switch check {
       case .existenceOfSuspiciousFiles:
@@ -45,17 +45,17 @@ internal class ReverseEngineeringToolsChecker {
       default:
         continue
       }
-      
+
       passed = passed && result.passed
-      
+
       if !result.passed {
         failedChecks.append((check: check, failMessage: result.failMessage))
       }
     }
-    
+
     return ReverseEngineeringToolsStatus(passed: passed, failedChecks: failedChecks)
   }
-  
+
   private static func checkDYLD() -> CheckResult {
     let suspiciousLibraries: Set<String> = [
       "FridaGadget",
@@ -63,31 +63,31 @@ internal class ReverseEngineeringToolsChecker {
       "cynject",
       "libcycript"
     ]
-    
+
     for index in 0..<_dyld_image_count() {
       let imageName = String(cString: _dyld_get_image_name(index))
-      
+
       // The fastest case insensitive contains check.
       for library in suspiciousLibraries where imageName.localizedCaseInsensitiveContains(library) {
         return (false, "Suspicious library loaded: \(imageName)")
       }
     }
-    
+
     return (true, "")
   }
-  
+
   private static func checkExistenceOfSuspiciousFiles() -> CheckResult {
     let paths = [
       "/usr/sbin/frida-server"
     ]
-    
+
     for path in paths where FileManager.default.fileExists(atPath: path) {
       return (false, "Suspicious file found: \(path)")
     }
-    
+
     return (true, "")
   }
-  
+
   private static func checkOpenedPorts() -> CheckResult {
     let ports = [
       27042, // default Frida
@@ -95,58 +95,58 @@ internal class ReverseEngineeringToolsChecker {
       22, // OpenSSH
       44 // checkra1n
     ]
-    
+
     for port in ports where canOpenLocalConnection(port: port) {
       return (false, "Port \(port) is open")
     }
-    
+
     return (true, "")
   }
-  
+
   private static func canOpenLocalConnection(port: Int) -> Bool {
     func swapBytesIfNeeded(port: in_port_t) -> in_port_t {
       let littleEndian = Int(OSHostByteOrder()) == OSLittleEndian
       return littleEndian ? _OSSwapInt16(port) : port
     }
-    
+
     var serverAddress = sockaddr_in()
     serverAddress.sin_family = sa_family_t(AF_INET)
     serverAddress.sin_addr.s_addr = inet_addr("127.0.0.1")
     serverAddress.sin_port = swapBytesIfNeeded(port: in_port_t(port))
     let sock = socket(AF_INET, SOCK_STREAM, 0)
-    
+
     let result = withUnsafePointer(to: &serverAddress) {
       $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
         connect(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.stride))
       }
     }
-    
+
     defer {
       close(sock)
     }
-    
+
     if result != -1 {
       return true // Port is opened
     }
-    
+
     return false
   }
-  
+
   // EXPERIMENTAL
   private static func checkPSelectFlag() -> CheckResult {
     var kinfo = kinfo_proc()
     var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
     var size = MemoryLayout<kinfo_proc>.stride
     let sysctlRet = sysctl(&mib, UInt32(mib.count), &kinfo, &size, nil, 0)
-    
+
     if sysctlRet != 0 {
       print("Error occurred when calling sysctl(). This check may not be reliable")
     }
-    
+
     if (kinfo.kp_proc.p_flag & P_SELECT) != 0 {
       return (false, "Suspicious PFlag value")
     }
-    
+
     return (true, "")
   }
 }

--- a/IOSSecuritySuite/RuntimeHookChecker.swift
+++ b/IOSSecuritySuite/RuntimeHookChecker.swift
@@ -15,7 +15,7 @@ internal class RuntimeHookChecker {
     FishHookChecker.denyFishHook("dladdr")
 #endif
   }()
-  
+
   static func amIRuntimeHook(
     dyldAllowList: [String],
     detectionClass: AnyClass,
@@ -28,41 +28,41 @@ internal class RuntimeHookChecker {
     } else {
       method = class_getInstanceMethod(detectionClass, selector)
     }
-    
+
     guard let method = method else {
       // method not found
       return true
     }
-    
+
     let imp = method_getImplementation(method)
     var info = Dl_info()
-    
+
     _ = swiftOnceDenyFishHooK
-    
+
     // dladdr will look through vm range of allImages for vm range of an Image that contains pointer 
     // of method and return info of the Image
     if dladdr(UnsafeRawPointer(imp), &info) != 1 {
       return false
     }
-    
+
     let impDyldPath = String(cString: info.dli_fname).lowercased()
-    
+
     // at system framework
     if impDyldPath.contains("/System/Library".lowercased()) {
       return false
     }
-    
+
     // at binary of app
     let binaryPath = String(cString: _dyld_get_image_name(0)).lowercased()
     if impDyldPath.contains(binaryPath) {
       return false
     }
-    
+
     // at whiteList
     if let impFramework = impDyldPath.components(separatedBy: "/").last {
       return !dyldAllowList.map({ $0.lowercased() }).contains(impFramework)
     }
-    
+
     // at injected framework
     return true
   }


### PR DESCRIPTION
This addresses all the swiftlint warnings of the project.

1. add `alwaysOutOfDate` in the xcodeproj since the swiftlint input is the entire project
2. `swiftlint lint --fix` for 99% of the changes here
3. replaced some `// swiftlint:disable` with `// swiftlint:disable:next` when only a single line was affected by a warning
4. manually fixed the warning in `for name in names`

![Capture d’écran 2025-11-25 à 19 28 31](https://github.com/user-attachments/assets/79341b77-8cdc-4b08-8f4d-2d8885e17510)
