### PR TITLE
feat(jailbreak): add modern jailbreak detection and performance tweak

### DIFF
--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -22,70 +22,74 @@ internal class JailbreakChecker {
     let failedChecks: [FailedCheckType]
   }
   
+  // Cache emulator check result to avoid redundant calls
+  private static var isEmulator: Bool {
+    return EmulatorChecker.amIRunInEmulator()
+  }
+  
   static func amIJailbroken() -> Bool {
-    return !performChecks().passed
+    // Fast path: exit early on first failure for simple boolean check
+    return performChecks(earlyExit: true).passed == false
   }
   
   static func amIJailbrokenWithFailMessage() -> (jailbroken: Bool, failMessage: String) {
-    let status = performChecks()
+    let status = performChecks(earlyExit: false)
     return (!status.passed, status.failMessage)
   }
   
   static func amIJailbrokenWithFailedChecks() -> (jailbroken: Bool,
                                                   failedChecks: [FailedCheckType]) {
-    let status = performChecks()
+    let status = performChecks(earlyExit: false)
     return (!status.passed, status.failedChecks)
   }
   
-  private static func performChecks() -> JailbreakStatus {
+  private static func performChecks(earlyExit: Bool = false) -> JailbreakStatus {
     var passed = true
-    var failMessage = ""
+    var failMessages: [String] = []
     var failedChecks: [FailedCheckType] = []
     
     for check in FailedCheck.allCases {
       let result = getResult(from: check)
       
-      passed = passed && result.passed
-      
       if !result.passed {
+        passed = false
         failedChecks.append((check: check, failMessage: result.failMessage))
+        failMessages.append(result.failMessage)
         
-        if !failMessage.isEmpty {
-          failMessage += ", "
+        // Early exit optimization for simple boolean check
+        if earlyExit {
+          return JailbreakStatus(passed: false, failMessage: result.failMessage, failedChecks: failedChecks)
         }
       }
-      
-      failMessage += result.failMessage
     }
     
-    return JailbreakStatus(passed: passed, failMessage: failMessage, failedChecks: failedChecks)
-    
-    func getResult(from check: FailedCheck) -> CheckResult {
-      switch check {
-      case .urlSchemes:
-        return checkURLSchemes()
-      case .existenceOfSuspiciousFiles:
-        return checkExistenceOfSuspiciousFiles()
-      case .suspiciousFilesCanBeOpened:
-        return checkSuspiciousFilesCanBeOpened()
-      case .restrictedDirectoriesWriteable:
-        return checkRestrictedDirectoriesWriteable()
-      case .fork:
-        if !EmulatorChecker.amIRunInEmulator() {
-          return checkFork()
-        } else {
-          print("App run in the emulator, skipping the fork check.")
-          return (true, "")
-        }
-      case .symbolicLinks:
-        return checkSymbolicLinks()
-      case .dyld:
-        return checkDYLD()
-      case .suspiciousObjCClasses:
-        return checkSuspiciousObjCClasses()
-      default:
+    return JailbreakStatus(passed: passed, failMessage: failMessages.joined(separator: ", "), failedChecks: failedChecks)
+  }
+  
+  private static func getResult(from check: FailedCheck) -> CheckResult {
+    switch check {
+    case .urlSchemes:
+      return checkURLSchemes()
+    case .existenceOfSuspiciousFiles:
+      return checkExistenceOfSuspiciousFiles()
+    case .suspiciousFilesCanBeOpened:
+      return checkSuspiciousFilesCanBeOpened()
+    case .restrictedDirectoriesWriteable:
+      return checkRestrictedDirectoriesWriteable()
+    case .fork:
+      if !isEmulator {
+        return checkFork()
+      } else {
         return (true, "")
       }
+    case .symbolicLinks:
+      return checkSymbolicLinks()
+    case .dyld:
+      return checkDYLD()
+    case .suspiciousObjCClasses:
+      return checkSuspiciousObjCClasses()
+    default:
+      return (true, "")
     }
   }
   
@@ -105,47 +109,113 @@ internal class JailbreakChecker {
   // "activator://" URL scheme has been removed for the same reason.
   private static func checkURLSchemes() -> CheckResult {
     let urlSchemes = [
-      "undecimus://",
-      "sileo://",
-      "zbra://",
-      "filza://"
+      "undecimus://",    // unc0ver
+      "sileo://",        // Sileo package manager
+      "zbra://",         // Zebra package manager
+      "filza://",        // Filza file manager
+      "dopamine://",     // Dopamine jailbreak
+      "palera1n://"      // palera1n jailbreak
     ]
     return canOpenUrlFromList(urlSchemes: urlSchemes)
   }
   
   private static func checkExistenceOfSuspiciousFiles() -> CheckResult {
     var paths = [
+      // Modern rootless jailbreaks (Dopamine, palera1n, roothide)
+      "/var/jb", // Rootless jailbreak prefix symlink
+      "/var/jb/usr/bin", // Rootless binaries
+      "/var/jb/Library/LaunchDaemons", // Rootless launch daemons
+      "/var/jb/etc/rc.d", // Rootless startup scripts
+      "/cores", // Temporary jailbreak filesystem mount point (palera1n)
+      "/var/Liy/.procursus_strapped", // Dopamine bootstrap marker
+      "/var/Liy", // Dopamine data directory
+      
+      // Dopamine-specific
+      "/Applications/Dopamine.app",
+      "/var/mobile/Library/Preferences/com.opa334.Dopamine.plist",
+      
+      // palera1n-specific
+      "/Applications/palera1nLoader.app",
+      "/usr/bin/palera1n-helper",
+      "/var/mobile/Library/Preferences/com.samiiau.loader.plist",
+      
+      // RootHide detection
+      "/var/mobile/Library/Preferences/com.roothide.pref.plist",
+      
+      // Ellekit (modern tweak injection)
+      "/usr/lib/libellekit.dylib",
+      "/var/jb/usr/lib/libellekit.dylib",
+      
+      // A-Bypass
       "/var/mobile/Library/Preferences/ABPattern", // A-Bypass
-      "/usr/lib/ABDYLD.dylib", // A-Bypass,
+      "/usr/lib/ABDYLD.dylib", // A-Bypass
       "/usr/lib/ABSubLoader.dylib", // A-Bypass
-      "/usr/sbin/frida-server", // frida
-      "/etc/apt/sources.list.d/electra.list", // electra
-      "/etc/apt/sources.list.d/sileo.sources", // electra
-      "/.bootstrapped_electra", // electra
-      "/usr/lib/libjailbreak.dylib", // electra
-      "/jb/lzma", // electra
-      "/.cydia_no_stash", // unc0ver
-      "/.installed_unc0ver", // unc0ver
-      "/jb/offsets.plist", // unc0ver
-      "/usr/share/jailbreak/injectme.plist", // unc0ver
-      "/etc/apt/undecimus/undecimus.list", // unc0ver
-      "/var/lib/dpkg/info/mobilesubstrate.md5sums", // unc0ver
+      
+      // Frida
+      "/usr/sbin/frida-server",
+      "/usr/lib/frida",
+      
+      // Electra
+      "/etc/apt/sources.list.d/electra.list",
+      "/etc/apt/sources.list.d/sileo.sources",
+      "/.bootstrapped_electra",
+      "/usr/lib/libjailbreak.dylib",
+      "/jb/lzma",
+      
+      // unc0ver
+      "/.cydia_no_stash",
+      "/.installed_unc0ver",
+      "/jb/offsets.plist",
+      "/usr/share/jailbreak/injectme.plist",
+      "/etc/apt/undecimus/undecimus.list",
+      "/var/lib/dpkg/info/mobilesubstrate.md5sums",
+      "/jb/jailbreakd.plist",
+      "/jb/amfid_payload.dylib",
+      "/jb/libjailbreak.dylib",
+      
+      // checkra1n
+      "/var/binpack",
+      "/var/binpack/Applications/loader.app",
+      
+      // Substrate/Substitute/libhooker
       "/Library/MobileSubstrate/MobileSubstrate.dylib",
-      "/jb/jailbreakd.plist", // unc0ver
-      "/jb/amfid_payload.dylib", // unc0ver
-      "/jb/libjailbreak.dylib", // unc0ver
+      "/Library/MobileSubstrate/CydiaSubstrate.dylib",
+      "/Library/MobileSubstrate/DynamicLibraries",
+      "/Library/MobileSubstrate/DynamicLibraries/SSLKillSwitch2.plist",
+      "/Library/MobileSubstrate/DynamicLibraries/PreferenceLoader.plist",
+      "/Library/MobileSubstrate/DynamicLibraries/PreferenceLoader.dylib",
+      "/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
+      "/Library/MobileSubstrate/DynamicLibraries/LiveClock.plist",
+      "/usr/lib/libhooker.dylib",
+      "/usr/lib/libsubstitute.dylib",
+      "/usr/lib/substrate",
+      "/usr/lib/TweakInject",
+      
+      // Cydia and package managers
       "/usr/libexec/cydia/firmware.sh",
       "/var/lib/cydia",
       "/etc/apt",
       "/private/var/lib/apt",
       "/var/log/apt",
       "/Applications/Cydia.app",
+      "/Applications/Sileo.app",
+      "/Applications/Zebra.app",
       "/private/var/stash",
-      "/private/var/lib/apt/",
       "/private/var/lib/cydia",
       "/private/var/cache/apt/",
       "/private/var/log/syslog",
       "/private/var/tmp/cydia.log",
+      
+      // Preference bundles (jailbreak tools)
+      "/Library/PreferenceBundles/LibertyPref.bundle",
+      "/Library/PreferenceBundles/ShadowPreferences.bundle",
+      "/Library/PreferenceBundles/ABypassPrefs.bundle",
+      "/Library/PreferenceBundles/FlyJBPrefs.bundle",
+      "/Library/PreferenceBundles/Cephei.bundle",
+      "/Library/PreferenceBundles/SubstitutePrefs.bundle",
+      "/Library/PreferenceBundles/libhbangprefs.bundle",
+      
+      // Legacy jailbreak apps
       "/Applications/Icy.app",
       "/Applications/MxTube.app",
       "/Applications/RockApp.app",
@@ -154,33 +224,13 @@ internal class JailbreakChecker {
       "/Applications/FakeCarrier.app",
       "/Applications/WinterBoard.app",
       "/Applications/IntelliScreen.app",
+      "/Applications/FlyJB.app",
+      "/Library/BawAppie/ABypass",
+      
+      // Other artifacts
       "/private/var/mobile/Library/SBSettings/Themes",
-      "/Library/MobileSubstrate/CydiaSubstrate.dylib",
       "/System/Library/LaunchDaemons/com.ikey.bbot.plist",
-      "/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
-      "/Library/MobileSubstrate/DynamicLibraries/LiveClock.plist",
       "/System/Library/LaunchDaemons/com.saurik.Cydia.Startup.plist",
-      "/Applications/Sileo.app",
-      "/var/binpack",
-      "/Library/PreferenceBundles/LibertyPref.bundle",
-      "/Library/PreferenceBundles/ShadowPreferences.bundle",
-      "/Library/PreferenceBundles/ABypassPrefs.bundle",
-      "/Library/PreferenceBundles/FlyJBPrefs.bundle",
-      "/Library/PreferenceBundles/Cephei.bundle",
-      "/Library/PreferenceBundles/SubstitutePrefs.bundle",
-      "/Library/PreferenceBundles/libhbangprefs.bundle",
-      "/usr/lib/libhooker.dylib",
-      "/usr/lib/libsubstitute.dylib",
-      "/usr/lib/substrate",
-      "/usr/lib/TweakInject",
-      "/var/binpack/Applications/loader.app", // checkra1n
-      "/Applications/FlyJB.app", // Fly JB X
-      "/Applications/Zebra.app", // Zebra
-      "/Library/BawAppie/ABypass", // ABypass
-      "/Library/MobileSubstrate/DynamicLibraries/SSLKillSwitch2.plist", // SSL Killswitch
-      "/Library/MobileSubstrate/DynamicLibraries/PreferenceLoader.plist", // PreferenceLoader
-      "/Library/MobileSubstrate/DynamicLibraries/PreferenceLoader.dylib", // PreferenceLoader
-      "/Library/MobileSubstrate/DynamicLibraries", // DynamicLibraries directory in general
       "/var/mobile/Library/Preferences/me.jjolano.shadow.plist"
     ]
     
@@ -309,6 +359,20 @@ internal class JailbreakChecker {
   }
   
   private static func checkSymbolicLinks() -> CheckResult {
+    // Check for /var/jb symlink - key indicator of modern rootless jailbreaks
+    // This symlink points to the jailbreak bootstrap (e.g., /private/preboot/.../procursus)
+    if let jbTarget = try? FileManager.default.destinationOfSymbolicLink(atPath: "/var/jb") {
+      return (false, "Rootless jailbreak symlink detected: /var/jb -> \(jbTarget)")
+    }
+    
+    // Check for RootHide-style randomized jbroot symlinks
+    // Pattern: /var/.jbroot-<hex>
+    if let contents = try? FileManager.default.contentsOfDirectory(atPath: "/var") {
+      for item in contents where item.hasPrefix(".jbroot-") {
+        return (false, "RootHide jailbreak directory detected: /var/\(item)")
+      }
+    }
+    
     let paths = [
       "/var/lib/undecimus/apt", // unc0ver
       "/Applications",
@@ -332,43 +396,71 @@ internal class JailbreakChecker {
     return (true, "")
   }
   
-  private static func checkDYLD() -> CheckResult {
-    let suspiciousLibraries: Set<String> = [
-      "systemhook.dylib", // Dopamine - hide jailbreak detection https://github.com/opa334/Dopamine/blob/dc1a1a3486bb5d74b8f2ea6ada782acdc2f34d0a/Application/Dopamine/Jailbreak/DOEnvironmentManager.m#L498
-      "roothideinit.dylib",
-      "SubstrateLoader.dylib",
-      "SSLKillSwitch2.dylib",
-      "SSLKillSwitch.dylib",
-      "MobileSubstrate.dylib",
-      "TweakInject.dylib",
-      "CydiaSubstrate",
-      "cynject",
-      "CustomWidgetIcons",
-      "PreferenceLoader",
-      "RocketBootstrap",
-      "WeeLoader",
-      "/.file", // HideJB (2.1.1) changes full paths of the suspicious libraries to "/.file"
-      "libhooker",
-      "SubstrateInserter",
-      "SubstrateBootstrap",
-      "ABypass",
-      "FlyJB",
-      "Substitute",
-      "Cephei",
-      "Electra",
-      "AppSyncUnified-FrontBoard.dylib",
-      "Shadow",
-      "FridaGadget",
-      "frida",
-      "libcycript"
-    ]
+  // Pre-computed lowercase suspicious library names for faster comparison
+  private static let suspiciousLibrariesLowercase: [String] = [
+    // Modern jailbreak hooks
+    "systemhook.dylib",      // Dopamine
+    "roothideinit.dylib",    // RootHide
+    "libellekit.dylib",      // Ellekit (modern tweak injection)
+    "libhooker.dylib",       // libhooker
+    "libblackjack.dylib",    // Dopamine
     
-    for index in 0..<_dyld_image_count() {
-      let imageName = String(cString: _dyld_get_image_name(index))
+    // Substrate/Substitute
+    "substrateloader.dylib",
+    "mobilesubstrate.dylib",
+    "tweakinject.dylib",
+    "cydiasubstrate",
+    "substrateinserter",
+    "substratebootstrap",
+    "libsubstitute.dylib",
+    "substitute",
+    
+    // SSL/Security bypass
+    "sslkillswitch2.dylib",
+    "sslkillswitch.dylib",
+    
+    // Debugging/RE tools
+    "fridagadget",
+    "frida",
+    "libcycript",
+    "cycript",
+    "cynject",
+    
+    // Anti-detection bypass tools
+    "abypass",
+    "flyjb",
+    "shadow",
+    "liberty",
+    "choicy",
+    "unsub",
+    "vnodebypass",
+    "hidejb",
+    "/.file",  // HideJB changes paths to "/.file"
+    
+    // Other suspicious libraries
+    "preferenceloader",
+    "rocketbootstrap",
+    "weeloader",
+    "customwidgeticons",
+    "cephei",
+    "electra",
+    "appsyncunified-frontboard.dylib",
+    "libhooker"
+  ]
+  
+  private static func checkDYLD() -> CheckResult {
+    let imageCount = _dyld_image_count()
+    
+    for index in 0..<imageCount {
+      guard let imageNamePtr = _dyld_get_image_name(index) else { continue }
+      let imageName = String(cString: imageNamePtr)
+      let imageNameLower = imageName.lowercased()
       
-      // The fastest case insensitive contains check.
-      for library in suspiciousLibraries where imageName.localizedCaseInsensitiveContains(library) {
-        return (false, "Suspicious library loaded: \(imageName)")
+      // Single pass through suspicious libraries with pre-lowercased names
+      for library in suspiciousLibrariesLowercase {
+        if imageNameLower.contains(library) {
+          return (false, "Suspicious library loaded: \(imageName)")
+        }
       }
     }
     
@@ -376,12 +468,31 @@ internal class JailbreakChecker {
   }
   
   private static func checkSuspiciousObjCClasses() -> CheckResult {
+    // Shadow - popular anti-jailbreak-detection bypass
     if let shadowRulesetClass = objc_getClass("ShadowRuleset") as? NSObject.Type {
       let selector = Selector(("internalDictionary"))
       if class_getInstanceMethod(shadowRulesetClass, selector) != nil {
-        return (false, "Shadow anti-anti-jailbreak detector detected :-)")
+        return (false, "Shadow anti-anti-jailbreak detector detected")
       }
     }
+    
+    // Check for other known jailbreak bypass tools
+    let suspiciousClasses = [
+      "UnSub",           // UnSub bypass tweak
+      "Choicy",          // Choicy tweak injection manager
+      "Liberty",         // Liberty Lite bypass
+      "FlyJB",           // FlyJB bypass
+      "ABypass",         // A-Bypass
+      "VnodeBypass",     // VnodeBypass
+      "HideJB"           // HideJB
+    ]
+    
+    for className in suspiciousClasses {
+      if objc_getClass(className) != nil {
+        return (false, "Jailbreak bypass tool detected: \(className)")
+      }
+    }
+    
     return (true, "")
   }
 }


### PR DESCRIPTION
Summary of Changes

1. Performance Optimizations
Early exit for simple boolean check: amIJailbroken() now exits immediately on first detection instead of running all checks
Optimized DYLD check: Pre-lowercase suspicious library names and use simple contains() instead of localizedCaseInsensitiveContains() per iteration
Better string building: Use array joining instead of manual string concatenation
Refactored nested function: Moved getResult() out of performChecks() for cleaner code

2. Modern Jailbreak Detection (2024-2026)
Added detection for:
Dopamine - /Applications/Dopamine.app, dopamine:// URL scheme, systemhook.dylib
palera1n - /Applications/palera1nLoader.app, palera1n:// URL scheme, /var/jb symlink
RootHide - /var/.jbroot-* directories, roothideinit.dylib
Ellekit - Modern tweak injection framework (libellekit.dylib)
Modern bypass tools - Choicy, UnSub, VnodeBypass, Liberty

3. Enhanced Detection Methods
/var/jb symlink check - Key indicator of all modern rootless jailbreaks
RootHide directory scanning - Detects randomized .jbroot-<hex> directories
Extended ObjC class detection - Checks for 7+ known bypass tool classes